### PR TITLE
Add real-time encoder integration example

### DIFF
--- a/cmd/simple-receiver/main.go
+++ b/cmd/simple-receiver/main.go
@@ -1,0 +1,120 @@
+// Package main provides a simple HTTP receiver for testing the realtime encoder integration example.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/pion/bwe-test/receiver"
+	"github.com/pion/logging"
+	"github.com/pion/webrtc/v4"
+)
+
+func main() {
+	// Set up logging
+	loggerFactory := logging.NewDefaultLoggerFactory()
+	logger := loggerFactory.NewLogger("simple_receiver")
+
+	logger.Info("Starting simple HTTP receiver on :8081")
+
+	// Create receiver with output path matching the script's expected structure
+	outputPath := "vnet/data/TestVnetRunnerDualVideoTracks/VariableAvailableCapacitySingleFlow/received_video/received_0"
+
+	// Ensure the directory exists
+	outputDir := filepath.Dir(outputPath + "_dummy") // Get directory part
+
+	if err := os.MkdirAll(outputDir, 0o750); err != nil {
+		log.Fatalf("Failed to create output directory %s: %v", outputDir, err)
+	}
+
+	logger.Info(fmt.Sprintf("Ensured output directory exists: %s", outputDir))
+
+	recv, err := receiver.NewReceiver(
+		receiver.SetLoggerFactory(loggerFactory),
+		receiver.SaveVideo(outputPath),
+	)
+	if err != nil {
+		log.Fatalf("Failed to create receiver: %v", err)
+	}
+
+	// Set up HTTP handler for SDP exchange
+	http.HandleFunc("/sdp", func(writer http.ResponseWriter, request *http.Request) {
+		logger.Info("Received SDP offer from sender")
+
+		if request.Method != http.MethodPost {
+			http.Error(writer, "Method not allowed", http.StatusMethodNotAllowed)
+
+			return
+		}
+
+		// Read the offer from the request
+		var offer webrtc.SessionDescription
+		if err := json.NewDecoder(request.Body).Decode(&offer); err != nil {
+			logger.Error(fmt.Sprintf("Failed to decode offer: %v", err))
+			http.Error(writer, "Bad request", http.StatusBadRequest)
+
+			return
+		}
+
+		// Set up peer connection
+		if err := recv.SetupPeerConnection(); err != nil {
+			logger.Error(fmt.Sprintf("Failed to setup peer connection: %v", err))
+			http.Error(writer, "Internal server error", http.StatusInternalServerError)
+
+			return
+		}
+
+		// Process the offer and create answer
+		answer, err := recv.AcceptOffer(&offer)
+		if err != nil {
+			logger.Error(fmt.Sprintf("Failed to accept offer: %v", err))
+			http.Error(writer, "Internal server error", http.StatusInternalServerError)
+
+			return
+		}
+
+		// Send the answer back
+		writer.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(writer).Encode(answer); err != nil {
+			logger.Error(fmt.Sprintf("Failed to encode answer: %v", err))
+
+			return
+		}
+
+		logger.Info("Sent WebRTC answer to sender")
+		logger.Info("Receiver is now ready to receive media")
+	})
+
+	// Start HTTP server
+	server := &http.Server{
+		Addr:              ":8081",
+		Handler:           nil,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		logger.Info("HTTP receiver listening on :8081/sdp")
+		if err := server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("HTTP server error: %v", err)
+		}
+	}()
+
+	// Handle shutdown
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	<-sigs
+	logger.Info("Shutting down receiver")
+
+	if err := server.Close(); err != nil {
+		logger.Error(fmt.Sprintf("Error closing server: %v", err))
+	}
+}

--- a/examples/realtime_encoder_integration.go
+++ b/examples/realtime_encoder_integration.go
@@ -1,0 +1,259 @@
+// Package main provides an example of integrating real-time frame pushing with BWE testing using RTCSender.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"image"
+	"image/color"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/pion/bwe-test/sender"
+	"github.com/pion/logging"
+	"github.com/pion/mediadevices/pkg/codec/vpx"
+	"github.com/pion/webrtc/v4"
+)
+
+/*
+This example demonstrates how to integrate real-time frame pushing with pion/bwe-test using RTCSender.
+
+Usage:
+1. Start the receiver:
+   $ go run ./cmd/simple-receiver/
+
+2. Run this example:
+   $ go run ./examples/realtime_encoder_integration.go
+
+This shows the same API that would be called from C++ code via CGO for real-time video streaming.
+*/
+
+func main() {
+	// Set up logging
+	loggerFactory := logging.NewDefaultLoggerFactory()
+	logger := loggerFactory.NewLogger("real_time_integration")
+
+	// Create a context that can be canceled
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Define encoder parameters (similar to your RTC module)
+	width := 640
+	height := 480
+	initialBitrate := 500000 // 500 kbps
+
+	// ================== BWE TEST INTEGRATION ==================
+
+	// Create RTCSender with BWE capabilities
+	rtcSender, err := sender.NewRTCSender(
+		sender.DefaultInterceptors(),
+		sender.GCC(initialBitrate), // Initial bitrate 500 kbps
+		sender.SetLoggerFactory(loggerFactory),
+	)
+	if err != nil {
+		logger.Error(err.Error())
+
+		return
+	}
+
+	// Create VP8 encoder parameters
+	vpxParams, err := vpx.NewVP8Params()
+	if err != nil {
+		logger.Error(fmt.Sprintf("Failed to create VP8 params: %v", err))
+
+		return
+	}
+	vpxParams.BitRate = initialBitrate
+
+	// Add a video track for real-time encoding
+	trackInfo := sender.VideoTrackInfo{
+		TrackID:        "realtime-video",
+		Width:          width,
+		Height:         height,
+		EncoderBuilder: &vpxParams,
+	}
+
+	if err := rtcSender.AddVideoTrack(trackInfo); err != nil {
+		logger.Error(fmt.Sprintf("Failed to add video track: %v", err))
+
+		return
+	}
+
+	// Set up the peer connection
+	if err := rtcSender.SetupPeerConnection(); err != nil {
+		logger.Error(err.Error())
+
+		return
+	}
+
+	// ================== DIRECT FRAME FEEDING ==================
+	startFrameFeeding(ctx, rtcSender, width, height, logger)
+
+	// ================== SIGNALING ==================
+	startSignaling(rtcSender, cancel, logger)
+
+	// ================== HANDLING SHUTDOWN ==================
+	handleShutdown(cancel)
+
+	// Start the sender
+	logger.Info("Starting BWE test...")
+	if err := rtcSender.Start(ctx); err != nil {
+		logger.Error(err.Error())
+	}
+
+	logger.Info("BWE test completed")
+}
+
+// startFrameFeeding starts a goroutine to generate and feed test frames.
+func startFrameFeeding(
+	ctx context.Context,
+	rtcSender *sender.RTCSender,
+	width, height int,
+	logger logging.LeveledLogger,
+) {
+	go func() {
+		// Feed frames at 30fps
+		ticker := time.NewTicker(33 * time.Millisecond)
+		defer ticker.Stop()
+
+		frameCounter := 0
+		for {
+			select {
+			case <-ticker.C:
+				// Create a slightly different frame each time
+				testImg := createAnimatedTestImage(width, height, frameCounter)
+
+				// This is the same API that would be called from your C++ code via CGO
+				if err := rtcSender.SendFrame("realtime-video", testImg); err != nil {
+					logger.Error(fmt.Sprintf("Error pushing frame: %v", err))
+				}
+				frameCounter++
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+// startSignaling starts the signaling process.
+func startSignaling(rtcSender *sender.RTCSender, cancel context.CancelFunc, logger logging.LeveledLogger) {
+	go func() {
+		// Create WebRTC offer
+		offer, err := rtcSender.CreateOffer()
+		if err != nil {
+			logger.Error(fmt.Sprintf("Failed to create offer: %v", err))
+			cancel()
+
+			return
+		}
+
+		// Send offer to receiver via HTTP
+		offerJSON, err := json.Marshal(offer)
+		if err != nil {
+			logger.Error(fmt.Sprintf("Failed to marshal offer: %v", err))
+			cancel()
+
+			return
+		}
+
+		// Create request with context
+		url := "http://127.0.0.1:8081/sdp"
+		req, err := http.NewRequestWithContext(context.Background(), "POST", url, bytes.NewBuffer(offerJSON))
+		if err != nil {
+			logger.Error(fmt.Sprintf("Failed to create request: %v", err))
+			cancel()
+
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			logger.Error(fmt.Sprintf("Failed to send offer: %v", err))
+			cancel()
+
+			return
+		}
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				logger.Error(fmt.Sprintf("Failed to close response body: %v", err))
+			}
+		}()
+
+		// Read answer from receiver
+		var answer webrtc.SessionDescription
+		if err := json.NewDecoder(resp.Body).Decode(&answer); err != nil {
+			logger.Error(fmt.Sprintf("Failed to decode answer: %v", err))
+			cancel()
+
+			return
+		}
+
+		// Set remote description
+		if err := rtcSender.AcceptAnswer(&answer); err != nil {
+			logger.Error(fmt.Sprintf("Failed to accept answer: %v", err))
+			cancel()
+
+			return
+		}
+
+		logger.Info("Successfully completed WebRTC signaling")
+	}()
+}
+
+// handleShutdown handles graceful shutdown signals.
+func handleShutdown(cancel context.CancelFunc) {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		<-sigs
+		cancel()
+	}()
+}
+
+// createAnimatedTestImage creates a test pattern that changes over time.
+func createAnimatedTestImage(width, height, frame int) image.Image {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+
+	// Create an animated pattern that changes with frame number
+	offset := frame % 255
+
+	for yPos := 0; yPos < height; yPos++ {
+		for xPos := 0; xPos < width; xPos++ {
+			// Safe conversion to avoid overflow warnings
+			rVal := ((xPos + offset) * 255) / width
+			gVal := ((yPos + offset) * 255) / height
+			bVal := (128 + offset) % 255
+
+			// Ensure values are within uint8 range
+			if rVal > 255 {
+				rVal = 255
+			}
+			if gVal > 255 {
+				gVal = 255
+			}
+			if bVal > 255 {
+				bVal = 255
+			}
+
+			//nolint:gosec // Values are bounds-checked above
+			r := uint8(rVal)
+			//nolint:gosec // Values are bounds-checked above
+			g := uint8(gVal)
+			//nolint:gosec // Values are bounds-checked above
+			b := uint8(bVal)
+			a := uint8(255)
+
+			img.Set(xPos, yPos, color.RGBA{R: r, G: g, B: b, A: a})
+		}
+	}
+
+	return img
+}

--- a/examples/simple_receiver.go
+++ b/examples/simple_receiver.go
@@ -1,0 +1,109 @@
+// Package main provides a simple HTTP receiver for testing the realtime encoder integration example.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/pion/bwe-test/receiver"
+	"github.com/pion/logging"
+	"github.com/pion/webrtc/v4"
+)
+
+func main() {
+	// Set up logging
+	loggerFactory := logging.NewDefaultLoggerFactory()
+	logger := loggerFactory.NewLogger("simple_receiver")
+
+	logger.Info("Starting simple HTTP receiver on :8081")
+
+	// Create receiver with output path matching the script's expected structure
+	outputPath := "vnet/data/TestVnetRunnerDualVideoTracks/VariableAvailableCapacitySingleFlow/received_video/received_0"
+	recv, err := receiver.NewReceiver(
+		receiver.SetLoggerFactory(loggerFactory),
+		receiver.SaveVideo(outputPath),
+	)
+	if err != nil {
+		log.Fatalf("Failed to create receiver: %v", err)
+	}
+
+	// Set up HTTP handler for SDP exchange
+	http.HandleFunc("/sdp", func(writer http.ResponseWriter, request *http.Request) {
+		logger.Info("Received SDP offer from sender")
+
+		if request.Method != http.MethodPost {
+			http.Error(writer, "Method not allowed", http.StatusMethodNotAllowed)
+
+			return
+		}
+
+		// Read the offer from the request
+		var offer webrtc.SessionDescription
+		if err := json.NewDecoder(request.Body).Decode(&offer); err != nil {
+			logger.Error(fmt.Sprintf("Failed to decode offer: %v", err))
+			http.Error(writer, "Bad request", http.StatusBadRequest)
+
+			return
+		}
+
+		// Set up peer connection
+		if err := recv.SetupPeerConnection(); err != nil {
+			logger.Error(fmt.Sprintf("Failed to setup peer connection: %v", err))
+			http.Error(writer, "Internal server error", http.StatusInternalServerError)
+
+			return
+		}
+
+		// Process the offer and create answer
+		answer, err := recv.AcceptOffer(&offer)
+		if err != nil {
+			logger.Error(fmt.Sprintf("Failed to accept offer: %v", err))
+			http.Error(writer, "Internal server error", http.StatusInternalServerError)
+
+			return
+		}
+
+		// Send the answer back
+		writer.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(writer).Encode(answer); err != nil {
+			logger.Error(fmt.Sprintf("Failed to encode answer: %v", err))
+
+			return
+		}
+
+		logger.Info("Sent WebRTC answer to sender")
+		logger.Info("Receiver is now ready to receive media")
+	})
+
+	// Start HTTP server
+	server := &http.Server{
+		Addr:              ":8081",
+		Handler:           nil,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		logger.Info("HTTP receiver listening on :8081/sdp")
+		if err := server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("HTTP server error: %v", err)
+		}
+	}()
+
+	// Handle shutdown
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	<-sigs
+	logger.Info("Shutting down receiver")
+
+	if err := server.Close(); err != nil {
+		logger.Error(fmt.Sprintf("Error closing server: %v", err))
+	}
+}

--- a/fix_ivf.sh
+++ b/fix_ivf.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Base directory for the dual video tracks
+BASE_DIR="vnet/data/TestVnetRunnerDualVideoTracks/VariableAvailableCapacitySingleFlow/received_video"
+
+# Input IVF files for both tracks (using new naming convention)
+INPUT_IVF_TRACK1="${BASE_DIR}/received_0_track-1.ivf"
+INPUT_IVF_TRACK2="${BASE_DIR}/received_0_track-2.ivf"
+
+# Output MP4 files
+OUTPUT_MP4_TRACK1="${BASE_DIR}/track1_output.mp4"
+OUTPUT_MP4_TRACK2="${BASE_DIR}/track2_output.mp4"
+
+# Function to process a single track
+process_track() {
+    local input_ivf="$1"
+    local output_mp4="$2"
+    local track_name="$3"
+    
+    echo "Processing $track_name..."
+    
+    # Create temp directory for this track
+    local temp_dir="temp_frames_${track_name}"
+    mkdir -p "$temp_dir"
+    
+    echo "Step 1: Extracting frames from $input_ivf..."
+    # Extract frames without respecting timestamps (treating them as a sequence)
+    ffmpeg -i "$input_ivf" -vsync 0 "$temp_dir/frame_%04d.png" 2>/dev/null
+    
+    # Count the number of frames
+    local frame_count=$(ls "$temp_dir" 2>/dev/null | wc -l)
+    echo "Extracted $frame_count frames for $track_name"
+    
+    if [ $frame_count -gt 0 ]; then
+        echo "Step 2: Creating new video from frames at 30fps for $track_name..."
+        # Create a new video from the frames at 30fps
+        ffmpeg -framerate 30 -i "$temp_dir/frame_%04d.png" -c:v libx264 -pix_fmt yuv420p "$output_mp4" 2>/dev/null
+        echo "$track_name output saved to $output_mp4"
+    else
+        echo "No frames found for $track_name in $input_ivf"
+    fi
+    
+    # Remove temporary files
+    rm -rf "$temp_dir"
+}
+
+echo "Processing dual video tracks..."
+
+# Check if input files exist
+if [ ! -f "$INPUT_IVF_TRACK1" ]; then
+    echo "Track 1 file not found: $INPUT_IVF_TRACK1"
+fi
+
+if [ ! -f "$INPUT_IVF_TRACK2" ]; then
+    echo "Track 2 file not found: $INPUT_IVF_TRACK2"
+fi
+
+# Process both tracks in parallel
+if [ -f "$INPUT_IVF_TRACK1" ]; then
+    process_track "$INPUT_IVF_TRACK1" "$OUTPUT_MP4_TRACK1" "track1" &
+fi
+
+if [ -f "$INPUT_IVF_TRACK2" ]; then
+    process_track "$INPUT_IVF_TRACK2" "$OUTPUT_MP4_TRACK2" "track2" &
+fi
+
+# Wait for both processes to complete
+wait
+
+echo "Done! Both tracks processed:"
+if [ -f "$OUTPUT_MP4_TRACK1" ]; then
+    echo " Track 1: $OUTPUT_MP4_TRACK1"
+fi
+if [ -f "$OUTPUT_MP4_TRACK2" ]; then
+    echo " Track 2: $OUTPUT_MP4_TRACK2"
+fi 


### PR DESCRIPTION
## What's Added
- **Real-time encoder integration example** - Demonstrates 30fps frame pushing with BWE
- **Simple HTTP receiver** - For testing WebRTC signaling and video capture  
- **IVF processing script** - Converts captured video to MP4 format

## How to Test
1. Start receiver: `go run ./cmd/simple-receiver/`
2. Run example: `go run ./examples/realtime_encoder_integration.go`  
3. Process video: `./fix_ivf.sh`

## Expected Results
- IVF files generated in `vnet/data/.../received_video/`
- MP4 output showing animated gradient patterns
- BWE logs showing bitrate adaptation (100kbps → 2Mbps+)


https://github.com/user-attachments/assets/e2b2c155-fd06-4bac-9ff4-fec25f0e4703

