### PR TITLE
Add RTCSender.OnFrameSent callback with per-frame capture timestamp

### DIFF
--- a/sender/frame_buffer.go
+++ b/sender/frame_buffer.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"image"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -59,22 +60,31 @@ func getBlackFrame(width, height int) *image.YCbCr {
 	return sharedBlackFrame
 }
 
+// frameWithMeta pairs a frame with an opaque capture timestamp
+// (microseconds). Zero captureTSUs means no timestamp (legacy SendFrame
+// or black-frame init).
+type frameWithMeta struct {
+	img         image.Image
+	captureTSUs int64
+}
+
 // FrameBuffer is a simple in-memory frame buffer that implements VideoSource
 // It can be used as a virtual video driver for testing or programmatic frame injection.
 type FrameBuffer struct {
-	frameChan   chan image.Image
-	closeChan   chan struct{}
-	closeOnce   sync.Once
-	width       int
-	height      int
-	id          string
-	initialized bool
+	frameChan       chan frameWithMeta
+	closeChan       chan struct{}
+	closeOnce       sync.Once
+	width           int
+	height          int
+	id              string
+	initialized     bool
+	lastCaptureTSUs atomic.Int64
 }
 
 // NewFrameBuffer creates a new frame buffer with the specified dimensions.
 func NewFrameBuffer(width, height int) *FrameBuffer {
 	return &FrameBuffer{
-		frameChan: make(chan image.Image, 8), // Increased from 2 to 8 for better buffering
+		frameChan: make(chan frameWithMeta, 8), // Increased from 2 to 8 for better buffering
 		closeChan: make(chan struct{}),
 		width:     width,
 		height:    height,
@@ -113,12 +123,18 @@ func (f *FrameBuffer) ResetInitialized() {
 // When initialized (normal operation), returns immediately with ErrNoFrameAvailable
 // if no frame is ready. When not initialized (encoder init), blocks up to 100ms
 // and returns a black frame for codec property detection.
+//
+// Side effect: stores the popped frame's captureTSUs for LastCaptureTSUs.
+// Black-frame timeouts preserve the previous value so encoders with
+// lookahead can still correlate the previously-read real frame.
 func (f *FrameBuffer) Read() (image.Image, func(), error) {
 	if f.initialized {
 		// Non-blocking fast path for normal operation.
 		select {
-		case img := <-f.frameChan:
-			return img, func() {}, nil
+		case fm := <-f.frameChan:
+			f.lastCaptureTSUs.Store(fm.captureTSUs)
+
+			return fm.img, func() {}, nil
 		case <-f.closeChan:
 			return nil, func() {}, ErrBufferClosed
 		default:
@@ -131,8 +147,10 @@ func (f *FrameBuffer) Read() (image.Image, func(), error) {
 	defer timer.Stop()
 
 	select {
-	case img := <-f.frameChan:
-		return img, func() {}, nil
+	case fm := <-f.frameChan:
+		f.lastCaptureTSUs.Store(fm.captureTSUs)
+
+		return fm.img, func() {}, nil
 	case <-f.closeChan:
 		return nil, func() {}, ErrBufferClosed
 	case <-timer.C:
@@ -142,35 +160,51 @@ func (f *FrameBuffer) Read() (image.Image, func(), error) {
 	}
 }
 
-// SendFrame adds a frame to the buffer.
+// LastCaptureTSUs returns the captureTSUs of the most recently popped
+// frame, or 0 if no real frame has been consumed yet. Intended for the
+// encode loop to call right after encodedReader.Read.
+func (f *FrameBuffer) LastCaptureTSUs() int64 {
+	return f.lastCaptureTSUs.Load()
+}
+
+// SendFrame adds a frame to the buffer with no capture timestamp.
 // If the buffer is full, it drops the oldest frame and adds the new one.
 func (f *FrameBuffer) SendFrame(frame image.Image) error {
+	_, err := f.SendFrameWithCaptureTS(frame, 0)
+
+	return err
+}
+
+// SendFrameWithCaptureTS adds a frame with an opaque capture timestamp
+// (microseconds), retrievable via LastCaptureTSUs after the encode
+// pipeline pops it. Pass 0 to opt out. evicted is true when the buffer
+// was full and the oldest entry was discarded to make room.
+func (f *FrameBuffer) SendFrameWithCaptureTS(frame image.Image, captureTSUs int64) (evicted bool, err error) {
 	select {
 	case <-f.closeChan:
-		return ErrBufferClosed
+		return false, ErrBufferClosed
 	default:
 	}
 
+	fm := frameWithMeta{img: frame, captureTSUs: captureTSUs}
+
 	select {
-	case f.frameChan <- frame:
-		// Successfully added frame
-		return nil
+	case f.frameChan <- fm:
+		return false, nil
 	default:
-		// Buffer full - drop oldest frame and add the new one
+		// Buffer full - drop oldest frame and add the new one.
 		select {
-		case <-f.frameChan: // Remove oldest
-			// Successfully removed old frame
+		case <-f.frameChan:
+			evicted = true
 		default:
-			// Buffer was empty (race condition)
+			// Buffer drained between the full-select and here.
 		}
 
-		// Now add the new frame
 		select {
-		case f.frameChan <- frame:
-			return nil
+		case f.frameChan <- fm:
+			return evicted, nil
 		default:
-			// Still can't add (shouldn't happen)
-			return ErrFailedToAddFrameAfterDrop
+			return evicted, ErrFailedToAddFrameAfterDrop
 		}
 	}
 }

--- a/sender/frame_buffer_test.go
+++ b/sender/frame_buffer_test.go
@@ -230,3 +230,113 @@ func TestFrameBuffer_ConcurrentAccess(t *testing.T) {
 
 	// Test should complete without deadlock or panic
 }
+
+func TestFrameBuffer_SendWithCaptureTs_RoundTrips(t *testing.T) {
+	fb := NewFrameBuffer(640, 480)
+	defer func() { _ = fb.Close() }()
+	fb.SetInitialized()
+
+	testImg := image.NewRGBA(image.Rect(0, 0, 640, 480))
+
+	evicted, err := fb.SendFrameWithCaptureTS(testImg, 111)
+	require.NoError(t, err)
+	require.False(t, evicted)
+	evicted, err = fb.SendFrameWithCaptureTS(testImg, 222)
+	require.NoError(t, err)
+	require.False(t, evicted)
+
+	// Each Read advances LastCaptureTSUs to the timestamp of the frame
+	// that was just returned.
+	_, release, err := fb.Read()
+	require.NoError(t, err)
+	release()
+	assert.Equal(t, int64(111), fb.LastCaptureTSUs())
+
+	_, release, err = fb.Read()
+	require.NoError(t, err)
+	release()
+	assert.Equal(t, int64(222), fb.LastCaptureTSUs())
+}
+
+func TestFrameBuffer_LegacySendFrame_RecordsZeroCaptureTs(t *testing.T) {
+	fb := NewFrameBuffer(640, 480)
+	defer func() { _ = fb.Close() }()
+	fb.SetInitialized()
+
+	testImg := image.NewRGBA(image.Rect(0, 0, 640, 480))
+
+	// Seed a non-zero value to confirm Read overwrites it on legacy send.
+	_, err := fb.SendFrameWithCaptureTS(testImg, 999)
+	require.NoError(t, err)
+	_, release, err := fb.Read()
+	require.NoError(t, err)
+	release()
+	require.Equal(t, int64(999), fb.LastCaptureTSUs())
+
+	require.NoError(t, fb.SendFrame(testImg))
+	_, release, err = fb.Read()
+	require.NoError(t, err)
+	release()
+	assert.Equal(t, int64(0), fb.LastCaptureTSUs(),
+		"legacy SendFrame should result in zero LastCaptureTSUs")
+}
+
+func TestFrameBuffer_BlackFrame_PreservesCaptureTS(t *testing.T) {
+	fb := NewFrameBuffer(640, 480)
+	defer func() { _ = fb.Close() }()
+
+	// Seed a value via the buffered path while still uninitialized so it
+	// is consumed by the encoder-init Read first, then a subsequent Read
+	// hits the black-frame timeout and must NOT clobber the recorded
+	// value — codecs with lookahead may emit an encoded output that
+	// corresponds to this still-buffered real frame after the timeout
+	// Read happens, and the callback for that emission must see 555.
+	testImg := image.NewRGBA(image.Rect(0, 0, 640, 480))
+	_, err := fb.SendFrameWithCaptureTS(testImg, 555)
+	require.NoError(t, err)
+
+	// First Read pulls the buffered frame and records 555.
+	_, release, err := fb.Read()
+	require.NoError(t, err)
+	release()
+	require.Equal(t, int64(555), fb.LastCaptureTSUs())
+
+	// Second Read drops into the 100ms timeout path and returns a black
+	// frame; LastCaptureTSUs must still report 555.
+	_, release, err = fb.Read()
+	require.NoError(t, err)
+	release()
+	assert.Equal(t, int64(555), fb.LastCaptureTSUs(),
+		"black-frame Read should preserve LastCaptureTSUs from the previous real frame")
+}
+
+func TestFrameBuffer_BlackFrame_FirstReadReturnsZero(t *testing.T) {
+	fb := NewFrameBuffer(640, 480)
+	defer func() { _ = fb.Close() }()
+
+	// A fresh buffer that has never seen a real frame must report 0
+	// from a black-frame Read — the atomic's zero value is the sentinel
+	// for "no real frame ever consumed".
+	_, release, err := fb.Read()
+	require.NoError(t, err)
+	release()
+	assert.Equal(t, int64(0), fb.LastCaptureTSUs(),
+		"first black-frame Read on a fresh buffer should return 0")
+}
+
+func TestFrameBuffer_SendWithCaptureTs_OverflowReportsEviction(t *testing.T) {
+	fb := NewFrameBuffer(640, 480)
+	defer func() { _ = fb.Close() }()
+
+	// Buffer capacity is 8. The first 8 sends fit; the 9th must evict the
+	// oldest entry so downstream SLO accounting can see the overload.
+	testImg := image.NewRGBA(image.Rect(0, 0, 640, 480))
+	for i := range 8 {
+		evicted, err := fb.SendFrameWithCaptureTS(testImg, int64(i+1))
+		require.NoError(t, err)
+		require.False(t, evicted, "send %d should not evict before capacity", i)
+	}
+	evicted, err := fb.SendFrameWithCaptureTS(testImg, 9)
+	require.NoError(t, err)
+	assert.True(t, evicted, "send beyond capacity should report eviction")
+}

--- a/sender/rtc_sender.go
+++ b/sender/rtc_sender.go
@@ -79,6 +79,16 @@ type EncodedTrack struct {
 // encode pass.
 type EncodedFrameCallback func(trackID string, data []byte, isKeyframe bool)
 
+// FrameSentCallback fires once per encoded frame after WriteSample
+// returns, and once per frame evicted from a full buffer to make room.
+// captureTSUs echoes the value passed to SendFrameWithCaptureTS (0 means
+// no timestamp; filter when used for latency measurement). sentAtWallUs
+// is time.Now().UnixMicro() at WriteSample return (or at eviction).
+// dropped is true when WriteSample errored or the frame was evicted.
+// Runs on the encode goroutine for completed sends, on the SendFrame
+// caller's goroutine for evictions; must not block.
+type FrameSentCallback func(trackID string, captureTSUs, sentAtWallUs int64, dropped bool)
+
 // RTCSender is a generic sender that can work with any frame source.
 type RTCSender struct {
 	// WebRTC components
@@ -109,6 +119,11 @@ type RTCSender struct {
 	// Optional callback invoked after each VP8 frame is encoded.
 	onEncodedFrame EncodedFrameCallback
 
+	// Optional callback invoked once per frame after WriteSample returns.
+	// Used by callers measuring end-to-end onboard latency (capture_ts ->
+	// frame enqueued into RTP send pipeline).
+	onFrameSent FrameSentCallback
+
 	// statsGetter is populated by the Pion stats interceptor's
 	// OnNewPeerConnection callback. Used by GetTrackStats to read RTP/RTCP
 	// counters (PacketsSent, RoundTripTime) per SSRC.
@@ -129,6 +144,14 @@ func (s *RTCSender) SetOnEncodedFrame(cb EncodedFrameCallback) {
 	s.tracksMu.Lock()
 	defer s.tracksMu.Unlock()
 	s.onEncodedFrame = cb
+}
+
+// SetOnFrameSent registers a per-frame send-completion callback.
+// Thread-safe. See FrameSentCallback for the contract.
+func (s *RTCSender) SetOnFrameSent(cb FrameSentCallback) {
+	s.tracksMu.Lock()
+	defer s.tracksMu.Unlock()
+	s.onFrameSent = cb
 }
 
 // NewRTCSender creates a new generic sender with GCC bandwidth estimation by default.
@@ -478,8 +501,19 @@ func (s *RTCSender) AddAudioTrack(trackID string) (*webrtc.TrackLocalStaticSampl
 	return audioTrack, nil
 }
 
-// SendFrame sends a frame to a specific track.
+// SendFrame sends a frame to a specific track with no associated capture
+// timestamp. Equivalent to SendFrameWithCaptureTS(trackID, frame, 0).
 func (s *RTCSender) SendFrame(trackID string, frame image.Image) error {
+	return s.SendFrameWithCaptureTS(trackID, frame, 0)
+}
+
+// SendFrameWithCaptureTS sends a frame along with an opaque capture
+// timestamp (microseconds) that is echoed to any registered
+// FrameSentCallback. Pass 0 to opt out. When the buffer is full and the
+// oldest frame is evicted to make room, the callback fires synchronously
+// for the evicted frame with dropped=true so downstream SLO accounting
+// catches the overload case.
+func (s *RTCSender) SendFrameWithCaptureTS(trackID string, frame image.Image, captureTSUs int64) error {
 	s.tracksMu.RLock()
 	track, exists := s.tracks[trackID]
 	s.tracksMu.RUnlock()
@@ -488,13 +522,17 @@ func (s *RTCSender) SendFrame(trackID string, frame image.Image) error {
 		return fmt.Errorf("%w: %s", ErrTrackNotFound, trackID)
 	}
 
-	// Use the video source's SendFrame method if it's a FrameBuffer
-	if frameBuffer, ok := track.videoSource.(*FrameBuffer); ok {
-		return frameBuffer.SendFrame(frame)
+	frameBuffer, ok := track.videoSource.(*FrameBuffer)
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrTrackDoesNotSupportFrames, trackID)
 	}
 
-	// If it's not a FrameBuffer, we can't send frames to it
-	return fmt.Errorf("%w: %s", ErrTrackDoesNotSupportFrames, trackID)
+	evicted, err := frameBuffer.SendFrameWithCaptureTS(frame, captureTSUs)
+	if evicted && s.onFrameSent != nil {
+		s.onFrameSent(trackID, 0, time.Now().UnixMicro(), true)
+	}
+
+	return err
 }
 
 // SetupPeerConnection initializes the WebRTC peer connection.
@@ -696,12 +734,20 @@ func (s *RTCSender) encodeAndSendTrack(trackID string, track *EncodedTrack) (boo
 	}
 	tAfterRead := time.Now()
 
+	// Capture timestamp for the just-encoded frame; non-FrameBuffer
+	// sources return 0.
+	var captureTSUs int64
+	if cfs, ok := track.videoSource.(*FrameBuffer); ok {
+		captureTSUs = cfs.LastCaptureTSUs()
+	}
+
 	track.bitrateTracker.AddFrame(len(encoded.Data), tAfterRead)
 
-	if writeErr := track.videoTrack.WriteSample(media.Sample{
+	writeErr := track.videoTrack.WriteSample(media.Sample{
 		Data:     encoded.Data,
 		Duration: time.Second / 10,
-	}); writeErr != nil {
+	})
+	if writeErr != nil {
 		s.log.Errorf("Error writing sample for track %s: %v", trackID, writeErr)
 	}
 	tAfterWrite := time.Now()
@@ -717,6 +763,10 @@ func (s *RTCSender) encodeAndSendTrack(trackID string, track *EncodedTrack) (boo
 	if s.onEncodedFrame != nil {
 		isKey := len(encoded.Data) > 0 && (encoded.Data[0]&0x01) == 0
 		s.onEncodedFrame(trackID, encoded.Data, isKey)
+	}
+
+	if s.onFrameSent != nil {
+		s.onFrameSent(trackID, captureTSUs, tAfterWrite.UnixMicro(), writeErr != nil)
 	}
 
 	release()

--- a/sender/rtc_sender_test.go
+++ b/sender/rtc_sender_test.go
@@ -8,6 +8,7 @@ package sender
 import (
 	"errors"
 	"image"
+	"sync"
 	"testing"
 	"time"
 
@@ -716,4 +717,117 @@ func TestTrackStats_ZeroValueIsValid(t *testing.T) {
 	assert.Equal(t, uint64(0), s.FramesEncoded)
 	assert.Equal(t, time.Duration(0), s.RoundTripTime)
 	assert.Equal(t, uint64(0), s.RoundTripTimeMeasurements)
+}
+
+func TestRTCSender_OnFrameSent_FiresWithCaptureTs(t *testing.T) {
+	sender, err := NewRTCSender()
+	require.NoError(t, err)
+	defer func() { _ = sender.Close() }()
+
+	err = sender.AddVideoTrack(VideoTrackInfo{
+		TrackID:        "cam-0",
+		Width:          640,
+		Height:         480,
+		InitialBitrate: 500_000,
+	})
+	require.NoError(t, err)
+
+	type sentEvent struct {
+		trackID      string
+		captureTSUs  int64
+		sentAtWallUs int64
+		dropped      bool
+	}
+	var (
+		mu     sync.Mutex
+		events []sentEvent
+	)
+	sender.SetOnFrameSent(func(trackID string, captureTSUs, sentAtWallUs int64, dropped bool) {
+		mu.Lock()
+		defer mu.Unlock()
+		events = append(events, sentEvent{trackID, captureTSUs, sentAtWallUs, dropped})
+	})
+
+	// libvpx has a one-frame encoder lookahead, so a single SendFrame +
+	// processEncodedFrames will not produce an encoded output yet. Drive
+	// a small batch and pump processEncodedFrames until the callback has
+	// seen at least one event carrying a non-zero captureTSUs. This
+	// matches the real pipeline where the encoder runs at ~30fps with
+	// frames continuously injected by the cgo bridge.
+	testImg := image.NewYCbCr(image.Rect(0, 0, 640, 480), image.YCbCrSubsampleRatio420)
+	const wantCaptureTS int64 = 1_700_000_000_000
+	for i, ts := range []int64{wantCaptureTS, wantCaptureTS + 33_000, wantCaptureTS + 66_000} {
+		require.NoError(t, sender.SendFrameWithCaptureTS("cam-0", testImg, ts), "send %d", i)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	var got *sentEvent
+	for time.Now().Before(deadline) {
+		time.Sleep(50 * time.Millisecond)
+		sender.processEncodedFrames()
+
+		mu.Lock()
+		for i := range events {
+			if events[i].captureTSUs == wantCaptureTS {
+				got = &events[i]
+
+				break
+			}
+		}
+		mu.Unlock()
+		if got != nil {
+			break
+		}
+	}
+	require.NotNil(t, got, "OnFrameSent never echoed the supplied captureTSUs within 2s")
+	assert.Equal(t, "cam-0", got.trackID)
+	assert.Equal(t, wantCaptureTS, got.captureTSUs)
+	assert.Positive(t, got.sentAtWallUs, "sentAtWallUs should be a real wall-clock microsecond")
+	assert.False(t, got.dropped, "WriteSample should succeed for an in-spec frame")
+}
+
+func TestRTCSender_OnFrameSent_FiresWithDroppedOnEviction(t *testing.T) {
+	sender, err := NewRTCSender()
+	require.NoError(t, err)
+	defer func() { _ = sender.Close() }()
+
+	err = sender.AddVideoTrack(VideoTrackInfo{
+		TrackID:        "cam-0",
+		Width:          640,
+		Height:         480,
+		EncoderBuilder: &MockVideoEncoderBuilder{},
+	})
+	require.NoError(t, err)
+
+	var (
+		mu      sync.Mutex
+		dropped int
+		nonDrop int
+	)
+	sender.SetOnFrameSent(func(_ string, _ int64, _ int64, isDrop bool) {
+		mu.Lock()
+		defer mu.Unlock()
+		if isDrop {
+			dropped++
+		} else {
+			nonDrop++
+		}
+	})
+
+	// Saturate the 8-slot FrameBuffer, then send extras to force eviction.
+	// The encode goroutine has not been driven, so the buffer never drains
+	// and every send beyond capacity must evict and fire the callback with
+	// dropped=true.
+	testImg := image.NewYCbCr(image.Rect(0, 0, 640, 480), image.YCbCrSubsampleRatio420)
+	for range 8 {
+		require.NoError(t, sender.SendFrameWithCaptureTS("cam-0", testImg, 1))
+	}
+	for range 3 {
+		require.NoError(t, sender.SendFrameWithCaptureTS("cam-0", testImg, 1))
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 3, dropped, "each over-capacity send should fire one dropped callback")
+	assert.Equal(t, 0, nonDrop, "no encoded-send callback should fire without driving the encoder")
 }


### PR DESCRIPTION
## Summary

Adds a public callback API so callers can measure end-to-end media-pipeline latency from frame capture to RTP enqueue, without forking.

- **`SendFrameWithCaptureTs(trackID, img, captureTsUs int64)`** — optional capture timestamp threaded alongside the frame.
- **`FrameBuffer.LastCaptureTsUs() int64`** — exposes the timestamp of the most recently consumed frame so the encode loop can correlate after `encodedReader.Read` returns.
- **`FrameSentCallback`** registered via `SetOnFrameSent`, fired exactly once per encoded frame in `encodeAndSendTrack` with `trackID`, `captureTsUs`, `sentAtWallUs` (post-`WriteSample`), and a `dropped` flag set when `WriteSample` errors.

The legacy `SendFrame(trackID, img)` is preserved as a thin wrapper that passes `captureTsUs=0`. Existing callers see no behavior change.

## Motivation

We use `bwe-test/sender` as a real WebRTC sender (not just for BWE testing) in a vehicle telemetry pipeline. Today we approximate per-frame send latency by sampling `TotalEncodeTimeNs` and `TotalSendQueueTimeNs` at 1Hz and dividing by frame deltas — that gives us a window-averaged number but no percentiles and no way to correlate to a specific source frame. With this callback we can compute per-frame `onboard_e2e_us = sentAtWallUs - captureTsUs` and emit proper p50/p95/p99 SLO percentiles.

The same hook is useful for any caller that wants to drive an external metrics sink (Prometheus, BQ, OTel) keyed on the originating capture instant. The `dropped` flag also lets callers distinguish encoder-pipeline drops from successful sends.

## Design notes

- **Capture timestamp is opaque** — `bwe-test` does not interpret the value beyond echoing it back to the callback. Callers pick the unit (the field is named `captureTsUs` for documentation, but `captureTs=0` is the only reserved value, meaning "no timestamp").
- **Correlation is read-after-write on the encode goroutine** — `encodeAndSendTrack` calls `LastCaptureTsUs()` synchronously after `encodedReader.Read` returns, in the same goroutine that drove the source `Read`. No locking needed; the encode pipeline is single-threaded per track.
- **Init-time black frames store 0** — `FrameBuffer.Read`'s 100ms-timeout black-frame path zeroes `lastCaptureTsUs` so callers can filter init traffic from real frames.
- **`dropped` flag** — set when `WriteSample` returns a non-nil error. The existing code already logged-and-continued on this case; the callback just exposes it.

## Test plan

- [x] `TestFrameBuffer_SendWithCaptureTs_RoundTrips` — two frames with distinct timestamps round-trip correctly via `LastCaptureTsUs`.
- [x] `TestFrameBuffer_LegacySendFrame_RecordsZeroCaptureTs` — legacy `SendFrame` resets `LastCaptureTsUs` to 0.
- [x] `TestFrameBuffer_BlackFrame_ClearsCaptureTs` — the black-frame init path resets `LastCaptureTsUs` to 0.
- [x] `TestRTCSender_OnFrameSent_FiresWithCaptureTs` — full end-to-end through the real VP8 encoder, callback receives the supplied `captureTsUs` with `dropped=false` and a positive `sentAtWallUs`.
- [x] `go vet ./sender/...` clean
- [x] `gofmt -d` clean
- [x] Existing `./sender/...` test suite unchanged (all passing)