### PR TITLE
Reduce FrameBuffer capacity from 8 to 2

### DIFF
--- a/sender/frame_buffer.go
+++ b/sender/frame_buffer.go
@@ -83,9 +83,16 @@ type FrameBuffer struct {
 }
 
 // NewFrameBuffer creates a new frame buffer with the specified dimensions.
+//
+// Capacity 2: one in-flight + one staged. Sized for low-latency real-time
+// senders where source > encoder rate. When the source is steady (no bursts
+// and no encoder slack to drain a backlog), encoder throughput is set by
+// encoder CPU capacity regardless of capacity, so a deeper queue only adds
+// wait time without delivering more frames. Capacity 2 tolerates one frame
+// of arrival/encode jitter; capacity 1 would drop on any same-tick burst.
 func NewFrameBuffer(width, height int) *FrameBuffer {
 	return &FrameBuffer{
-		frameChan: make(chan frameWithMeta, 8), // Increased from 2 to 8 for better buffering
+		frameChan: make(chan frameWithMeta, 2),
 		closeChan: make(chan struct{}),
 		width:     width,
 		height:    height,

--- a/sender/frame_buffer_test.go
+++ b/sender/frame_buffer_test.go
@@ -374,15 +374,15 @@ func TestFrameBuffer_SendWithCaptureTs_OverflowReportsEviction(t *testing.T) {
 	fb := NewFrameBuffer(640, 480)
 	defer func() { _ = fb.Close() }()
 
-	// Buffer capacity is 8. The first 8 sends fit; the 9th must evict the
+	// Buffer capacity is 2. The first 2 sends fit; the 3rd must evict the
 	// oldest entry so downstream SLO accounting can see the overload.
 	testImg := image.NewRGBA(image.Rect(0, 0, 640, 480))
-	for i := range 8 {
+	for i := range 2 {
 		evicted, err := fb.SendFrameWithCaptureTS(testImg, int64(i+1))
 		require.NoError(t, err)
 		require.False(t, evicted, "send %d should not evict before capacity", i)
 	}
-	evicted, err := fb.SendFrameWithCaptureTS(testImg, 9)
+	evicted, err := fb.SendFrameWithCaptureTS(testImg, 3)
 	require.NoError(t, err)
 	assert.True(t, evicted, "send beyond capacity should report eviction")
 }

--- a/sender/rtc_sender_test.go
+++ b/sender/rtc_sender_test.go
@@ -757,14 +757,16 @@ func TestRTCSender_OnFrameSent_FiresWithCaptureTs(t *testing.T) {
 
 	// libvpx has a one-frame encoder lookahead, so a single SendFrame +
 	// processEncodedFrames will not produce an encoded output yet. Drive
-	// a small batch and pump processEncodedFrames until the callback has
-	// seen at least one event carrying a non-zero captureTSUs. This
-	// matches the real pipeline where the encoder runs at ~30fps with
-	// frames continuously injected by the cgo bridge.
+	// a small batch and pump processEncodedFrames between sends so the
+	// 2-slot FrameBuffer drains and the first frame is not evicted before
+	// the encoder consumes it. This matches the real pipeline where the
+	// encoder runs at ~30fps with frames continuously injected by the
+	// cgo bridge.
 	testImg := image.NewYCbCr(image.Rect(0, 0, 640, 480), image.YCbCrSubsampleRatio420)
 	const wantCaptureTS int64 = 1_700_000_000_000
 	for i, ts := range []int64{wantCaptureTS, wantCaptureTS + 33_000, wantCaptureTS + 66_000} {
 		require.NoError(t, sender.SendFrameWithCaptureTS("cam-0", testImg, ts), "send %d", i)
+		sender.processEncodedFrames()
 	}
 
 	deadline := time.Now().Add(2 * time.Second)
@@ -831,12 +833,12 @@ func TestRTCSender_OnFrameSent_FiresWithDroppedOnEviction(t *testing.T) {
 		}
 	})
 
-	// Saturate the 8-slot FrameBuffer, then send extras to force eviction.
+	// Saturate the 2-slot FrameBuffer, then send extras to force eviction.
 	// The encode goroutine has not been driven, so the buffer never drains
 	// and every send beyond capacity must evict and fire the callback with
 	// dropped=true.
 	testImg := image.NewYCbCr(image.Rect(0, 0, 640, 480), image.YCbCrSubsampleRatio420)
-	for range 8 {
+	for range 2 {
 		require.NoError(t, sender.SendFrameWithCaptureTS("cam-0", testImg, 1))
 	}
 	for range 3 {


### PR DESCRIPTION
## Why

For real-time senders where the source rate exceeds the encoder rate (steady state — no bursts, no encoder slack), buffer depth doesn't change delivered FPS. Encoder throughput is set by encoder CPU capacity, so any extra queue depth just *adds latency* without delivering more frames.

We hit this empirically in a production RTC pipeline:

| Source | Encoder | Capacity 8 (today) | Capacity 2 |
|---|---|---|---|
| 11.4 fps | 8.8 fps | buffer_wait p99 ≈ 760 ms | buffer_wait p99 ≈ 230 ms |
| (same) | (same) | drop rate 23% | drop rate 23% |
| (same) | (same) | delivered FPS 8.8 | delivered FPS 8.8 |

The original `8` here was an `// Increased from 2 to 8 for better buffering` heuristic, but for our case the buffer was just hiding source-encoder rate mismatch behind ~600 ms of accumulated latency. Delivered frames waited behind soon-to-be-dropped frames.

  Headline: depth-8 vs depth-2 deltas (comparing to carbench k8oh0443 baseline):

  
| Stage | depth=8 (k8oh0443) | depth=2 (nb62w34i) | Change |
  |---|---|---|---|
  | buffer_wait p50 | 181 ms | 97 ms | -46% |
  | buffer_wait p99 | 761 ms | 199 ms | -74% |
  | total p50 | 310 ms | 162 ms | -48% |
  | total p99 | 903 ms | 299 ms | -67% |

## Why 2 (not 1)

- Capacity 1 drops on any same-tick burst — a single source-arrival jitter event evicts the in-flight frame.
- Capacity 2 keeps **one in-flight + one staged**: tolerates one frame of arrival/encode jitter while bounding wait at `~2 × encoder_period`.

## Effect on consumers

- **Steady source > encoder rate**: same delivered FPS, same drop rate, lower latency. ✅
- **Bursty source with encoder slack to drain**: capacity 2 will drop frames that capacity 8 absorbed. Senders that need this catch-up behavior (smooth out variable-rate cameras) should keep capacity 8 — happy to make it configurable via an option if there's interest, but I think the low-latency default is the better one for real-time use.

## Tests

Two existing tests asserted capacity-bound behavior and have been updated:

- `TestFrameBuffer_SendWithCaptureTs_OverflowReportsEviction` — fills buffer to new cap (2) then asserts the next send reports `evicted=true`.
- `TestRTCSender_OnFrameSent_FiresWithDroppedOnEviction` — saturates the new cap (2) then sends 3 more, asserts 3 drop callbacks.

One unrelated test (`TestRTCSender_OnFrameSent_FiresWithCaptureTs`) was sending 3 frames in rapid succession into the same buffer without draining; with capacity 2 the first frame was evicted before the encoder could consume it. Fixed by driving `processEncodedFrames` between sends, which matches the real-pipeline behavior where the encoder drains continuously.

All `go test ./sender/... -count=1` pass.