### PR TITLE
Serialize recreateEncoder with encode goroutine

### DIFF
--- a/sender/rtc_sender.go
+++ b/sender/rtc_sender.go
@@ -66,6 +66,11 @@ type EncodedTrack struct {
 	// bitrateMu serializes access to bitrateTracker; AddFrame runs on the
 	// encode goroutine and GetBitrate runs on the BWE update path.
 	bitrateMu sync.Mutex
+	// encoderMu protects the encoder lifecycle. The per-track encode
+	// goroutine holds RLock from encodedReader.Read through release();
+	// recreateEncoder takes Lock to swap the reader without racing the
+	// goroutine's in-flight release callback.
+	encoderMu sync.RWMutex
 	mimeType  string
 
 	// rtpSender is set after AddTrack and used to look up the SSRC when
@@ -770,10 +775,10 @@ func (s *RTCSender) runEncodeLoop(ctx context.Context, trackID string, track *En
 			if ctx.Err() != nil || errors.Is(err, ErrBufferClosed) {
 				return
 			}
-			// FrameBuffer.Read is non-blocking; sleep briefly so we don't
-			// busy-spin between frame arrivals while still leaving the vpx
-			// encoder's internal mutex free for concurrent DynamicQPControl
-			// bitrate updates.
+			// Source had no frame this iteration. Sleep briefly to avoid
+			// busy-spinning and to release the vpx encoder mutex (held
+			// during Read) between attempts so concurrent DynamicQPControl
+			// bitrate updates can acquire it.
 			if errors.Is(err, ErrNoFrameAvailable) {
 				time.Sleep(5 * time.Millisecond)
 
@@ -793,16 +798,20 @@ func (s *RTCSender) runEncodeLoop(ctx context.Context, trackID string, track *En
 // Returns true if a frame was successfully processed, or an error.
 func (s *RTCSender) encodeAndSendTrack(trackID string, track *EncodedTrack) (bool, error) {
 	s.tracksMu.RLock()
-	encodedReader := track.encodedReader
 	videoTrack := track.videoTrack
 	videoSource := track.videoSource
 	onEncodedFrame := s.onEncodedFrame
 	onFrameSent := s.onFrameSent
 	s.tracksMu.RUnlock()
 
+	// encoderMu.RLock spans Read..release so recreateEncoder cannot
+	// swap or close the encoder underneath an in-flight read.
+	track.encoderMu.RLock()
+	defer track.encoderMu.RUnlock()
+
 	// Read includes VP8 encode — this is the expensive call.
 	tBeforeRead := time.Now()
-	encoded, release, err := encodedReader.Read()
+	encoded, release, err := track.encodedReader.Read()
 	if err != nil {
 		return false, err
 	}
@@ -928,6 +937,13 @@ func (s *RTCSender) recreateEncodersForActivatedTracks(newAllocation map[string]
 // after a track has been idle for a long time.
 // Must be called while holding tracksMu.Lock.
 func (s *RTCSender) recreateEncoder(track *EncodedTrack) error {
+	// encoderMu.Lock excludes the per-track encode goroutine for the
+	// duration of the swap. Without this, the goroutine can be inside
+	// encodedReader.Read or holding a release() callback while we close
+	// the old reader, racing on encoder state and FrameBuffer access.
+	track.encoderMu.Lock()
+	defer track.encoderMu.Unlock()
+
 	// Temporarily reset FrameBuffer to uninitialized so NewEncodedReader
 	// can read a black frame for codec property detection during init.
 	// Always restore to initialized afterward, regardless of success or failure.


### PR DESCRIPTION
## Why

After #156 (event-driven encode), `SetBitrateAllocation` calling `recreateEncoder` on a 0→positive transition can race the per-track encode goroutine:

1. The encode goroutine snapshots `track.encodedReader` under `tracksMu.RLock`, releases the lock, then calls `Read()` on the snapshotted pointer.
2. `recreateEncoder` runs under `tracksMu.Lock()` and does:
   - `fb.ResetInitialized()` (temporarily flips FrameBuffer's Read semantics)
   - `mediaTrack.NewEncodedReader(...)` (creates a second encoder consuming from the same FrameBuffer)
   - `track.encodedReader.Close()` (destroys the old encoder)
   - swaps `track.encodedReader`

Race vectors:

- **`release()` after `Close()`**: the goroutine's in-flight `Read()` returns `(encoded, release, err)`. By the time it invokes `release()`, the old encoder may have been destroyed. Whether that's a no-op, double-free, or UAF depends on pion/mediadevices internals; not a documented contract.
- **Concurrent FrameBuffer access**: during `NewEncodedReader`'s codec-detection reads, the old encoder is still consuming from the same FrameBuffer. Real frames can be stolen between the two encoders.
- **Black-frame emission**: while `fb` is uninitialized, the old encoder's pending `Read` falls through the uninitialized path and can emit a black frame as if real.

`vpx.encoder.mu` serializes `Read` vs `Close` at the vpx layer, so the bare crash window inside `Close`-mid-Read is narrow — but the `release()`-after-`Close()` window is not protected by it.

## Fix

Per-track `encoderMu sync.RWMutex`.

- The encode goroutine takes `encoderMu.RLock()` immediately before `encodedReader.Read()` and holds it through `release()`. The lock is released regardless of success/error via `defer`.
- `recreateEncoder` takes `encoderMu.Lock()` for the duration of the swap (FrameBuffer reset, `NewEncodedReader`, `Close`, pointer assignment).

Lock ordering (consistent, no deadlock):

- Writers: `tracksMu.Lock` then `encoderMu.Lock`.
- Readers: `tracksMu.RLock` for a brief snapshot, then `tracksMu.RUnlock`, then `encoderMu.RLock` — locks are never nested.

Cost: `encoderMu.Lock` blocks until the in-flight encode cycle (Read + WriteSample + release) completes — tens of ms typically. `recreateEncoder` is infrequent (0→positive bitrate transitions only), so the latency cost is acceptable.

## Tests

- `go test -race -count=1 ./sender/...` — clean.
- `go test -race -bench BenchmarkUpdateBitrate -benchtime=500ms` — clean, no regression vs main.

Reported by @jcui on a downstream consumer that calls `SetBitrateAllocation` immediately after `AddVideoTrack` during init, triggering 0→positive transitions on every track while encode goroutines are already running.
