### PR TITLE
Add poll-free single-slot encode loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ bin/
 vendor/
 node_modules/
 
+### Binaries ###
+################
+vnet/vnet
+
 ### Files ###
 #############
 *.ivf

--- a/sender/frame_buffer.go
+++ b/sender/frame_buffer.go
@@ -73,6 +73,7 @@ type frameWithMeta struct {
 type FrameBuffer struct {
 	frameChan         chan frameWithMeta
 	closeChan         chan struct{}
+	notifyChan        chan struct{}
 	closeOnce         sync.Once
 	width             int
 	height            int
@@ -84,25 +85,53 @@ type FrameBuffer struct {
 
 // NewFrameBuffer creates a new frame buffer with the specified dimensions.
 //
-// Capacity 2: one in-flight + one staged. Sized for low-latency real-time
-// senders where source > encoder rate. When the source is steady (no bursts
-// and no encoder slack to drain a backlog), encoder throughput is set by
-// encoder CPU capacity regardless of capacity, so a deeper queue only adds
-// wait time without delivering more frames. Capacity 2 tolerates one frame
-// of arrival/encode jitter; capacity 1 would drop on any same-tick burst.
+// Capacity 1: a single-slot "latest frame" mailbox. At most one frame may be
+// in-flight in the encoder while at most one newer frame waits staged; each
+// new SendFrame overwrites the staged frame (drop-oldest in
+// SendFrameWithCaptureTS), so the encoder always pulls the freshest image and
+// stale frames are discarded under load. This minimizes per-frame buffer wait
+// at the cost of dropping on any same-tick burst — intentional for
+// low-latency teleoperation where a newer frame always supersedes an older
+// one. Encoder throughput remains bounded by encoder CPU, not queue depth.
 func NewFrameBuffer(width, height int) *FrameBuffer {
 	return &FrameBuffer{
-		frameChan: make(chan frameWithMeta, 2),
-		closeChan: make(chan struct{}),
-		width:     width,
-		height:    height,
-		id:        "frame-buffer",
+		frameChan:  make(chan frameWithMeta, 1),
+		closeChan:  make(chan struct{}),
+		notifyChan: make(chan struct{}, 1),
+		width:      width,
+		height:     height,
+		id:         "frame-buffer",
 	}
 }
 
 // ID returns the identifier for this video source.
 func (f *FrameBuffer) ID() string {
 	return f.id
+}
+
+// FrameReady returns a channel that receives a value when a frame is
+// enqueued. It is buffered (cap 1) and edge-triggered: signal() drops the
+// notification if one is already pending, so a consumer that drains all
+// available frames after each wake-up never misses a frame. This lets the
+// encode loop block for a frame instead of polling, eliminating poll-induced
+// buffer-wait latency.
+func (f *FrameBuffer) FrameReady() <-chan struct{} {
+	return f.notifyChan
+}
+
+// Closed returns a channel closed when the buffer is closed, so a consumer
+// blocked on FrameReady can wake and observe ErrBufferClosed.
+func (f *FrameBuffer) Closed() <-chan struct{} {
+	return f.closeChan
+}
+
+// signal performs a non-blocking notify that a frame is available. If a
+// notification is already pending it is a no-op (edge-triggered).
+func (f *FrameBuffer) signal() {
+	select {
+	case f.notifyChan <- struct{}{}:
+	default:
+	}
 }
 
 // Close stops the frame buffer and releases resources.
@@ -218,6 +247,8 @@ func (f *FrameBuffer) SendFrameWithCaptureTS(frame image.Image, captureTSUs int6
 
 	select {
 	case f.frameChan <- fm:
+		f.signal()
+
 		return false, nil
 	default:
 		// Buffer full - drop oldest frame and add the new one.
@@ -230,6 +261,8 @@ func (f *FrameBuffer) SendFrameWithCaptureTS(frame image.Image, captureTSUs int6
 
 		select {
 		case f.frameChan <- fm:
+			f.signal()
+
 			return evicted, nil
 		default:
 			return evicted, ErrFailedToAddFrameAfterDrop

--- a/sender/frame_buffer_test.go
+++ b/sender/frame_buffer_test.go
@@ -98,7 +98,7 @@ func TestFrameBuffer_BufferFull(t *testing.T) {
 	fb := NewFrameBuffer(640, 480)
 	defer func() { _ = fb.Close() }()
 
-	// Fill the buffer beyond capacity (buffer size is 8)
+	// Fill the buffer beyond capacity (buffer size is 1)
 	testImg := image.NewRGBA(image.Rect(0, 0, 640, 480))
 
 	// Send more frames than buffer capacity
@@ -237,19 +237,21 @@ func TestFrameBuffer_SendWithCaptureTs_RoundTrips(t *testing.T) {
 
 	testImg := image.NewRGBA(image.Rect(0, 0, 640, 480))
 
+	// Capacity 1: drain between sends so each frame round-trips without
+	// being evicted by the next. Each Read advances LastCaptureTSUs to the
+	// timestamp of the frame that was just returned.
 	evicted, err := fb.SendFrameWithCaptureTS(testImg, 111)
 	require.NoError(t, err)
 	require.False(t, evicted)
-	evicted, err = fb.SendFrameWithCaptureTS(testImg, 222)
-	require.NoError(t, err)
-	require.False(t, evicted)
 
-	// Each Read advances LastCaptureTSUs to the timestamp of the frame
-	// that was just returned.
 	_, release, err := fb.Read()
 	require.NoError(t, err)
 	release()
 	assert.Equal(t, int64(111), fb.LastCaptureTSUs())
+
+	evicted, err = fb.SendFrameWithCaptureTS(testImg, 222)
+	require.NoError(t, err)
+	require.False(t, evicted)
 
 	_, release, err = fb.Read()
 	require.NoError(t, err)
@@ -373,15 +375,14 @@ func TestFrameBuffer_SendWithCaptureTs_OverflowReportsEviction(t *testing.T) {
 	fb := NewFrameBuffer(640, 480)
 	defer func() { _ = fb.Close() }()
 
-	// Buffer capacity is 2. The first 2 sends fit; the 3rd must evict the
+	// Buffer capacity is 1. The first send fits; the 2nd must evict the
 	// oldest entry so downstream SLO accounting can see the overload.
 	testImg := image.NewRGBA(image.Rect(0, 0, 640, 480))
-	for i := range 2 {
-		evicted, err := fb.SendFrameWithCaptureTS(testImg, int64(i+1))
-		require.NoError(t, err)
-		require.False(t, evicted, "send %d should not evict before capacity", i)
-	}
-	evicted, err := fb.SendFrameWithCaptureTS(testImg, 3)
+	evicted, err := fb.SendFrameWithCaptureTS(testImg, 1)
+	require.NoError(t, err)
+	require.False(t, evicted, "first send should not evict before capacity")
+
+	evicted, err = fb.SendFrameWithCaptureTS(testImg, 2)
 	require.NoError(t, err)
 	assert.True(t, evicted, "send beyond capacity should report eviction")
 }

--- a/sender/rtc_sender.go
+++ b/sender/rtc_sender.go
@@ -486,6 +486,7 @@ func (s *RTCSender) AddVideoTrack(info VideoTrackInfo) error {
 		}()
 	}
 
+	//nolint:gosec // G118: trackCancel is stored in track.encodeCancel and called during teardown (Close/RemoveTrack).
 	trackCtx, trackCancel := context.WithCancel(context.Background())
 	track.encodeCancel = trackCancel
 	s.tracksMu.Unlock()
@@ -763,6 +764,19 @@ func (s *RTCSender) updateBitrate(targetBitrate int) {
 func (s *RTCSender) runEncodeLoop(ctx context.Context, trackID string, track *EncodedTrack) {
 	defer close(track.encodeDone)
 
+	// The encode loop waits on the buffer's enqueue signal instead of polling
+	// on empty. videoSource is always a *FrameBuffer (set in AddVideoTrack) and
+	// never swapped (recreateEncoder only replaces encodedReader), so these
+	// channels stay valid across encoder recreation.
+	fb, ok := track.videoSource.(*FrameBuffer)
+	if !ok {
+		s.log.Errorf("track %s has no FrameBuffer source; encode loop exiting", trackID)
+
+		return
+	}
+	frameReady := fb.FrameReady()
+	bufClosed := fb.Closed()
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -772,19 +786,9 @@ func (s *RTCSender) runEncodeLoop(ctx context.Context, trackID string, track *En
 
 		hasFrame, err := s.encodeAndSendTrack(trackID, track)
 		if err != nil {
-			if ctx.Err() != nil || errors.Is(err, ErrBufferClosed) {
+			if s.handleEncodeErr(ctx, err, trackID, frameReady, bufClosed) {
 				return
 			}
-			// Source had no frame this iteration. Sleep briefly to avoid
-			// busy-spinning and to release the vpx encoder mutex (held
-			// during Read) between attempts so concurrent DynamicQPControl
-			// bitrate updates can acquire it.
-			if errors.Is(err, ErrNoFrameAvailable) {
-				time.Sleep(5 * time.Millisecond)
-
-				continue
-			}
-			s.log.Errorf("Error processing track %s: %v", trackID, err)
 
 			continue
 		}
@@ -792,6 +796,35 @@ func (s *RTCSender) runEncodeLoop(ctx context.Context, trackID string, track *En
 			track.lastEncodeAtWallUs.Store(time.Now().UnixMicro())
 		}
 	}
+}
+
+// handleEncodeErr processes an error from encodeAndSendTrack. It returns true
+// when the encode loop should exit. For ErrNoFrameAvailable the source had no
+// frame this iteration; encodeAndSendTrack has already released the vpx encoder
+// mutex (held only across Read), so we wait OUTSIDE it — recreateEncoder and
+// DynamicQPControl bitrate updates can acquire encoderMu.Lock while we idle. We
+// block on the enqueue signal instead of polling so a freshly pushed frame is
+// picked up immediately, eliminating poll-induced buffer-wait latency.
+func (s *RTCSender) handleEncodeErr(
+	ctx context.Context, err error, trackID string,
+	frameReady, bufClosed <-chan struct{},
+) bool {
+	if ctx.Err() != nil || errors.Is(err, ErrBufferClosed) {
+		return true
+	}
+	if errors.Is(err, ErrNoFrameAvailable) {
+		select {
+		case <-ctx.Done():
+			return true
+		case <-bufClosed:
+			return true
+		case <-frameReady:
+			return false
+		}
+	}
+	s.log.Errorf("Error processing track %s: %v", trackID, err)
+
+	return false
 }
 
 // encodeAndSendTrack reads, encodes, and sends a single track's frame.

--- a/sender/rtc_sender_test.go
+++ b/sender/rtc_sender_test.go
@@ -687,20 +687,25 @@ func TestRTCSender_OnFrameSent_FiresWithCaptureTs(t *testing.T) {
 	})
 
 	// Event-driven encode loop is always running, so feed frames at a small
-	// interval to avoid overflowing the 2-slot source buffer while still
-	// exercising capture timestamp echoing through the callback path.
+	// interval while exercising capture timestamp echoing through the callback
+	// path. The source buffer is a single-slot newest-wins mailbox (capacity
+	// 1): under encoder backpressure older frames may be evicted, but the
+	// final frame is never superseded, so it must round-trip and echo its
+	// captureTS on the success path.
 	testImg := image.NewYCbCr(image.Rect(0, 0, 640, 480), image.YCbCrSubsampleRatio420)
-	const wantCaptureTS int64 = 1_700_000_000_000
-	for i, ts := range []int64{
-		wantCaptureTS,
-		wantCaptureTS + 33_000,
-		wantCaptureTS + 66_000,
-		wantCaptureTS + 99_000,
-		wantCaptureTS + 132_000,
-	} {
+	const baseCaptureTS int64 = 1_700_000_000_000
+	timestamps := []int64{
+		baseCaptureTS,
+		baseCaptureTS + 33_000,
+		baseCaptureTS + 66_000,
+		baseCaptureTS + 99_000,
+		baseCaptureTS + 132_000,
+	}
+	for i, ts := range timestamps {
 		require.NoError(t, sender.SendFrameWithCaptureTS("cam-0", testImg, ts), "send %d", i)
 		time.Sleep(10 * time.Millisecond)
 	}
+	wantCaptureTS := timestamps[len(timestamps)-1]
 
 	deadline := time.Now().Add(2 * time.Second)
 	var got *sentEvent
@@ -709,7 +714,7 @@ func TestRTCSender_OnFrameSent_FiresWithCaptureTs(t *testing.T) {
 
 		mu.Lock()
 		for i := range events {
-			if events[i].captureTSUs == wantCaptureTS {
+			if events[i].captureTSUs == wantCaptureTS && !events[i].dropped {
 				got = &events[i]
 
 				break
@@ -765,20 +770,17 @@ func TestRTCSender_OnFrameSent_FiresWithDroppedOnEviction(t *testing.T) {
 		}
 	})
 
-	// Saturate the 2-slot FrameBuffer, then send extras to force eviction.
-	// The encode goroutine has not been driven, so the buffer never drains
-	// and every send beyond capacity must evict and fire the callback with
-	// dropped=true.
+	// Saturate the single-slot FrameBuffer, then send extras to force
+	// eviction. The encode goroutine has not been driven, so the buffer never
+	// drains and every send beyond capacity (1) must evict and fire the
+	// callback with dropped=true. 5 sends -> 1 fits, 4 evict.
 	testImg := image.NewYCbCr(image.Rect(0, 0, 640, 480), image.YCbCrSubsampleRatio420)
-	for range 2 {
-		require.NoError(t, sender.SendFrameWithCaptureTS("cam-0", testImg, 1))
-	}
-	for range 3 {
+	for range 5 {
 		require.NoError(t, sender.SendFrameWithCaptureTS("cam-0", testImg, 1))
 	}
 
 	mu.Lock()
 	defer mu.Unlock()
-	assert.Equal(t, 3, dropped, "each over-capacity send should fire one dropped callback")
+	assert.Equal(t, 4, dropped, "each over-capacity send should fire one dropped callback")
 	assert.Equal(t, 0, nonDrop, "no encoded-send callback should fire without driving the encoder")
 }


### PR DESCRIPTION
## Summary

Replace the per-track 5ms encode poll with an event-driven, newest-wins
pipeline. Each track now encodes off the buffer's enqueue signal, so the
freshest captured frame is always the one encoded and stale frames are
dropped rather than queued — reducing onboard latency under load.

## Changes

- **Single-slot `FrameBuffer`**: keeps only the latest frame. Enqueue
  overwrites the slot and signals `FrameReady`; a `Closed` channel lets a
  blocked reader wake immediately on close.
- **Poll-free `runEncodeLoop`**: blocks on `FrameReady` instead of a 5ms
  `time.Sleep` poll, so a freshly pushed frame is picked up right away.
  Error handling is factored into `handleEncodeErr` to keep cyclomatic
  complexity within the `cyclop` limit.
- **Dead-code & lint cleanup**: removed the unreachable non-`FrameBuffer`
  poll fallback (`videoSource` is always a `*FrameBuffer`), silenced the
  `gosec` G118 false positive on the per-track cancel func (it is stored
  on the track and called at teardown), and restored `vnet/vnet` to
  `.gitignore`.

## Testing

- `go build ./...`
- `golangci-lint run ./sender/...` — 0 issues
- `go test ./sender/...` — passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)