### PR TITLE
Add FIR, BWE bitrate, and quality-limitation to TrackStats

### DIFF
--- a/sender/rtc_sender.go
+++ b/sender/rtc_sender.go
@@ -84,6 +84,24 @@ type EncodedTrack struct {
 	totalSendQueueTimeNs atomic.Uint64
 	lastEncodeAtWallUs   atomic.Int64
 
+	// targetBitrate is this track's allocated share (bps) last pushed to the
+	// encoder by updateBitrate. Read by GetTrackStats as the W3C
+	// outbound-rtp `targetBitrate`.
+	targetBitrate atomic.Int64
+
+	// Synthesized quality-limitation accounting (pion provides no encoder
+	// feedback, so we infer it). qlCPUNs / qlBandwidthNs accumulate the wall
+	// time spent CPU- / bandwidth-limited; qlLastTickWallUs and qlLastOverruns
+	// are the per-tick baselines used by accumulateQualityLimitation.
+	qlCPUNs          atomic.Uint64
+	qlBandwidthNs    atomic.Uint64
+	qlLastTickWallUs atomic.Int64
+	qlLastOverruns   atomic.Uint64
+
+	// encodeOverruns counts frames evicted from a full buffer because the
+	// producer outpaced the encode loop — the CPU-limited signal.
+	encodeOverruns atomic.Uint64
+
 	encodeCancel context.CancelFunc
 	encodeDone   chan struct{}
 }
@@ -123,6 +141,13 @@ type RTCSender struct {
 
 	// Bandwidth estimation
 	estimatorChan chan cc.BandwidthEstimator
+
+	// availableOutgoingBitrate is the latest GCC estimate (bps), connection-level.
+	// Stored by the Start loop, read by GetTrackStats.
+	availableOutgoingBitrate atomic.Int64
+	// maxBitrate is the configured GCC cap (bps); 0 means no cap. Used to infer
+	// the bandwidth-limited state for quality-limitation accounting.
+	maxBitrate int
 
 	// Bitrate allocation (protected by tracksMu)
 	bitrateAllocation map[string]float64 // Track ID -> percentage (0.0 to 1.0)
@@ -213,6 +238,7 @@ func NewRTCSender(opts ...Option) (*RTCSender, error) {
 // setupGCC sets up Google Congestion Control with the specified initial and max bitrate.
 // A maxBitrate of 0 means no cap (uses GCC default of 50 Mbps).
 func (s *RTCSender) setupGCC(initialBitrate, maxBitrate int) error {
+	s.maxBitrate = maxBitrate
 	controller, err := cc.NewInterceptor(func() (cc.BandwidthEstimator, error) {
 		opts := []gcc.Option{gcc.SendSideBWEInitialBitrate(initialBitrate)}
 		if maxBitrate > 0 {
@@ -279,10 +305,24 @@ func (s *RTCSender) setupStats() error {
 // outbound video track. Cumulative since track creation; callers that want
 // per-window deltas should snapshot two reads and subtract.
 type TrackStats struct {
+	// Bandwidth (bps). AvailableOutgoingBitrate is the connection-level GCC
+	// estimate; TargetBitrate is this track's allocated share pushed to the
+	// encoder (W3C outbound-rtp `targetBitrate`).
+	AvailableOutgoingBitrate int
+	TargetBitrate            int
+
 	// Pipeline counters from the local encode loop.
 	FramesEncoded        uint64
 	TotalEncodeTimeNs    uint64 // wall time spent inside encodedReader.Read
 	TotalSendQueueTimeNs uint64 // wall time between Read return and WriteSample return
+
+	// Synthesized quality-limitation durations (seconds), W3C outbound-rtp
+	// `qualityLimitationDurations` semantics. Bandwidth-limited is inferred from
+	// the GCC estimate sitting below the configured max bitrate; CPU-limited is
+	// inferred from the encode loop falling behind (buffer evictions). When GCC
+	// has no max cap, bandwidth-limited cannot be inferred and stays zero.
+	QualityLimitationCPUSeconds       float64
+	QualityLimitationBandwidthSeconds float64
 
 	// Network counters from the Pion stats interceptor.
 	PacketsSent     uint64
@@ -290,6 +330,7 @@ type TrackStats struct {
 	HeaderBytesSent uint64
 	NACKCount       uint32
 	PLICount        uint32
+	FIRCount        uint32
 
 	// Remote receiver counters (from RTCP RR).
 	PacketsReceived           uint64
@@ -318,9 +359,13 @@ func (s *RTCSender) GetTrackStats(trackID string) *TrackStats {
 	}
 
 	out := &TrackStats{
-		FramesEncoded:        track.framesEncoded.Load(),
-		TotalEncodeTimeNs:    track.totalEncodeTimeNs.Load(),
-		TotalSendQueueTimeNs: track.totalSendQueueTimeNs.Load(),
+		AvailableOutgoingBitrate:          int(s.availableOutgoingBitrate.Load()),
+		TargetBitrate:                     int(track.targetBitrate.Load()),
+		FramesEncoded:                     track.framesEncoded.Load(),
+		TotalEncodeTimeNs:                 track.totalEncodeTimeNs.Load(),
+		TotalSendQueueTimeNs:              track.totalSendQueueTimeNs.Load(),
+		QualityLimitationCPUSeconds:       float64(track.qlCPUNs.Load()) / 1e9,
+		QualityLimitationBandwidthSeconds: float64(track.qlBandwidthNs.Load()) / 1e9,
 	}
 
 	s.statsGetterMu.RLock()
@@ -349,6 +394,7 @@ func (s *RTCSender) GetTrackStats(trackID string) *TrackStats {
 	out.HeaderBytesSent = netStats.OutboundRTPStreamStats.HeaderBytesSent
 	out.NACKCount = netStats.OutboundRTPStreamStats.NACKCount
 	out.PLICount = netStats.OutboundRTPStreamStats.PLICount
+	out.FIRCount = netStats.OutboundRTPStreamStats.FIRCount
 
 	out.PacketsReceived = netStats.RemoteInboundRTPStreamStats.PacketsReceived
 	out.PacketsLost = netStats.RemoteInboundRTPStreamStats.PacketsLost
@@ -564,6 +610,10 @@ func (s *RTCSender) SendFrameWithCaptureTS(trackID string, frame image.Image, ca
 
 	evicted, err := frameBuffer.SendFrameWithCaptureTS(frame, captureTSUs)
 	if evicted {
+		// A full buffer means the encode loop is falling behind the producer:
+		// the CPU-limited signal for quality-limitation accounting.
+		track.encodeOverruns.Add(1)
+
 		s.tracksMu.RLock()
 		onFrameSent := s.onFrameSent
 		s.tracksMu.RUnlock()
@@ -682,6 +732,7 @@ func (s *RTCSender) Start(ctx context.Context) error {
 			return nil
 		case <-ticker.C:
 			targetBitrate := estimator.GetTargetBitrate()
+			s.availableOutgoingBitrate.Store(int64(targetBitrate))
 			s.updateBitrate(targetBitrate)
 		}
 	}
@@ -738,9 +789,12 @@ func (s *RTCSender) updateBitrate(targetBitrate int) {
 
 	useCustomAllocation := len(s.bitrateAllocation) > 0
 	equalShare := targetBitrate / len(s.tracks)
+	nowUs := time.Now().UnixMicro()
 
 	for trackID, track := range s.tracks {
 		trackBitrate := s.calculateTrackBitrate(trackID, targetBitrate, equalShare, useCustomAllocation)
+		track.targetBitrate.Store(int64(trackBitrate))
+		s.accumulateQualityLimitation(track, nowUs)
 
 		// Only update encoder for tracks with positive bitrate (like NuroSender)
 		if trackBitrate > 0 {
@@ -758,6 +812,39 @@ func (s *RTCSender) updateBitrate(targetBitrate int) {
 		s.log.Debugf("Updated bitrate to %d bps using custom allocation", targetBitrate)
 	} else {
 		s.log.Debugf("Updated bitrate to %d bps (%d per track)", targetBitrate, equalShare)
+	}
+}
+
+// accumulateQualityLimitation attributes the wall time elapsed since the last
+// tick to a quality-limitation bucket for the track. It is called once per
+// updateBitrate tick (≈100ms) while holding tracksMu. Classification each tick:
+//
+//   - bandwidth-limited: a GCC cap is configured and the current estimate sits
+//     below it, so the rate is being held down by the network;
+//   - else CPU-limited: the encode loop fell behind since the last tick (a
+//     frame was evicted from a full buffer);
+//   - else neither (no accumulation).
+//
+// The first call only establishes the baselines and accumulates nothing.
+func (s *RTCSender) accumulateQualityLimitation(track *EncodedTrack, nowUs int64) {
+	lastUs := track.qlLastTickWallUs.Swap(nowUs)
+	overruns := track.encodeOverruns.Load()
+	prevOverruns := track.qlLastOverruns.Swap(overruns)
+	if lastUs == 0 {
+		return // baseline tick
+	}
+
+	elapsedNs := (nowUs - lastUs) * 1000
+	if elapsedNs <= 0 {
+		return
+	}
+
+	avail := int(s.availableOutgoingBitrate.Load())
+	switch {
+	case s.maxBitrate > 0 && avail < s.maxBitrate:
+		track.qlBandwidthNs.Add(uint64(elapsedNs)) //nolint:gosec // G115: elapsedNs > 0 by guard above
+	case overruns > prevOverruns:
+		track.qlCPUNs.Add(uint64(elapsedNs)) //nolint:gosec // G115: elapsedNs > 0 by guard above
 	}
 }
 

--- a/sender/rtc_sender_test.go
+++ b/sender/rtc_sender_test.go
@@ -607,6 +607,7 @@ func TestRTCSender_GetTrackStats_PopulatesNetworkCounters(t *testing.T) {
 				HeaderBytesSent: 7000,
 				NACKCount:       2,
 				PLICount:        1,
+				FIRCount:        3,
 			},
 			RemoteInboundRTPStreamStats: stats.RemoteInboundRTPStreamStats{
 				ReceivedRTPStreamStats: stats.ReceivedRTPStreamStats{
@@ -631,6 +632,7 @@ func TestRTCSender_GetTrackStats_PopulatesNetworkCounters(t *testing.T) {
 	assert.Equal(t, uint64(7000), got.HeaderBytesSent)
 	assert.Equal(t, uint32(2), got.NACKCount)
 	assert.Equal(t, uint32(1), got.PLICount)
+	assert.Equal(t, uint32(3), got.FIRCount)
 
 	assert.Equal(t, uint64(1200), got.PacketsReceived)
 	assert.Equal(t, int64(34), got.PacketsLost)
@@ -639,6 +641,87 @@ func TestRTCSender_GetTrackStats_PopulatesNetworkCounters(t *testing.T) {
 	assert.Equal(t, 40*time.Millisecond, got.RoundTripTime)
 	assert.Equal(t, 4*time.Second, got.TotalRoundTripTime)
 	assert.Equal(t, uint64(100), got.RoundTripTimeMeasurements)
+}
+
+func TestRTCSender_GetTrackStats_BitrateFields(t *testing.T) {
+	sender, err := NewRTCSender()
+	require.NoError(t, err)
+	defer func() { _ = sender.Close() }()
+
+	err = sender.AddVideoTrack(VideoTrackInfo{
+		TrackID:        "cam-0",
+		Width:          640,
+		Height:         480,
+		EncoderBuilder: &MockVideoEncoderBuilder{},
+	})
+	require.NoError(t, err)
+
+	// Mimic one Start-loop iteration: record the BWE estimate, then allocate.
+	const estimate = 2_500_000
+	sender.availableOutgoingBitrate.Store(int64(estimate))
+	sender.updateBitrate(estimate)
+
+	got := sender.GetTrackStats("cam-0")
+	require.NotNil(t, got)
+	assert.Equal(t, estimate, got.AvailableOutgoingBitrate)
+	// Single track, equal share => the whole estimate is allocated to it.
+	assert.Equal(t, estimate, got.TargetBitrate)
+}
+
+func TestRTCSender_GetTrackStats_QualityLimitation(t *testing.T) {
+	t.Run("bandwidth", func(t *testing.T) {
+		sender, err := NewRTCSender()
+		require.NoError(t, err)
+		defer func() { _ = sender.Close() }()
+
+		require.NoError(t, sender.AddVideoTrack(VideoTrackInfo{
+			TrackID: "cam-0", Width: 640, Height: 480, EncoderBuilder: &MockVideoEncoderBuilder{},
+		}))
+
+		// GCC estimate sits below the configured cap => bandwidth-limited.
+		sender.maxBitrate = 5_000_000
+		sender.availableOutgoingBitrate.Store(1_000_000)
+
+		sender.updateBitrate(1_000_000) // baseline tick
+		time.Sleep(5 * time.Millisecond)
+		sender.updateBitrate(1_000_000) // accumulating tick
+
+		got := sender.GetTrackStats("cam-0")
+		require.NotNil(t, got)
+		assert.Positive(t, got.QualityLimitationBandwidthSeconds,
+			"bandwidth-limited seconds should accumulate when estimate < max")
+		assert.Zero(t, got.QualityLimitationCPUSeconds)
+	})
+
+	t.Run("cpu", func(t *testing.T) {
+		sender, err := NewRTCSender()
+		require.NoError(t, err)
+		defer func() { _ = sender.Close() }()
+
+		require.NoError(t, sender.AddVideoTrack(VideoTrackInfo{
+			TrackID: "cam-0", Width: 640, Height: 480, EncoderBuilder: &MockVideoEncoderBuilder{},
+		}))
+
+		// No cap => bandwidth can't be inferred; a buffer eviction since the
+		// last tick is the CPU-limited signal.
+		sender.maxBitrate = 0
+		sender.availableOutgoingBitrate.Store(1_000_000)
+
+		sender.tracksMu.RLock()
+		track := sender.tracks["cam-0"]
+		sender.tracksMu.RUnlock()
+
+		sender.updateBitrate(1_000_000) // baseline tick
+		track.encodeOverruns.Add(1)     // encode loop fell behind
+		time.Sleep(5 * time.Millisecond)
+		sender.updateBitrate(1_000_000) // accumulating tick
+
+		got := sender.GetTrackStats("cam-0")
+		require.NotNil(t, got)
+		assert.Positive(t, got.QualityLimitationCPUSeconds,
+			"cpu-limited seconds should accumulate on buffer eviction")
+		assert.Zero(t, got.QualityLimitationBandwidthSeconds)
+	})
 }
 
 func TestTrackStats_ZeroValueIsValid(t *testing.T) {


### PR DESCRIPTION
## Summary

Extends `RTCSender.GetTrackStats` so downstream RealtimeAnalytics metrics have real sources, without changing audio behavior.

- **`FIRCount`** — copied from the Pion stats interceptor's `OutboundRTPStreamStats` (feeds `ra_webrtc_fir_count`).
- **`AvailableOutgoingBitrate`** — latest GCC estimate (connection-level), stored by the `Start` loop. **`TargetBitrate`** — the per-track allocated share pushed to the encoder, stored in `updateBitrate` (feed `ra_webrtc_available_outgoing_bitrate_bps` / `ra_webrtc_target_bitrate_bps`).
- **`QualityLimitation{CPU,Bandwidth}Seconds`** — synthesized per ≈100ms tick in `accumulateQualityLimitation`, since pion provides no encoder feedback (feed `ra_video_encoder_quality_limitation_{cpu,bandwidth}_seconds`):
  - **bandwidth-limited** when the GCC estimate sits below the configured max bitrate;
  - **CPU-limited** when the encode loop falls behind (buffer eviction, tracked via `encodeOverruns`);
  - when GCC has **no max cap**, bandwidth-limited cannot be inferred and stays zero.

## Out of scope

Audio send-side stats (`ra_audio_*`) are deferred. Audio tracks remain published externally via LiveKit and are not added to the sender's PeerConnection, so audio behavior is unchanged from `main`.

## Testing

- `go build ./...`, `go vet ./...`
- `go test ./sender/...` (incl. new `BitrateFields`, `QualityLimitation` cpu/bandwidth, and `FIRCount` assertions)
- `go test -race -run 'GetTrackStats|AddAudioTrack|SetupPeerConnection|QualityLimitation' ./sender/...`
- `golangci-lint run ./sender/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)