### PR TITLE
sender: add LookupNetStatsBySSRC for senders added outside AddVideoTrack

### DIFF
--- a/sender/rtc_sender.go
+++ b/sender/rtc_sender.go
@@ -342,6 +342,67 @@ type TrackStats struct {
 	RoundTripTimeMeasurements uint64
 }
 
+// SenderNetStats is the per-SSRC network-side subset of TrackStats: counters
+// the pion stats interceptor records from outbound RTP + remote RTCP, with no
+// pipeline (encoder) fields. Returned by LookupNetStatsBySSRC for senders that
+// were not added through AddVideoTrack (e.g. tracks added directly via
+// pc.AddTrack on the same PeerConnection), where pipeline counters don't
+// apply. Field semantics mirror the same-named fields on TrackStats.
+type SenderNetStats struct {
+	PacketsSent     uint64
+	BytesSent       uint64
+	HeaderBytesSent uint64
+	NACKCount       uint32
+	PLICount        uint32
+
+	PacketsReceived           uint64
+	PacketsLost               int64
+	Jitter                    float64
+	FractionLost              float64
+	RoundTripTime             time.Duration
+	TotalRoundTripTime        time.Duration
+	RoundTripTimeMeasurements uint64
+}
+
+// LookupNetStatsBySSRC returns the pion stats interceptor's network counters
+// for any sender on the underlying PeerConnection, identified by its outbound
+// SSRC. Use this for tracks added directly to the PC (e.g. via pc.AddTrack)
+// rather than through AddVideoTrack — AddVideoTrack-managed tracks should
+// keep using GetTrackStats, which also surfaces pipeline (encoder) counters.
+//
+// Returns nil when the stats interceptor has not yet bound to a
+// PeerConnection or has no entry for the SSRC (the latter being normal until
+// the first RTP packet has been sent for that sender). RTT-bearing fields
+// stay zero until at least one RTCP receiver report has arrived for the SSRC,
+// matching GetTrackStats' contract.
+func (s *RTCSender) LookupNetStatsBySSRC(ssrc webrtc.SSRC) *SenderNetStats {
+	s.statsGetterMu.RLock()
+	getter := s.statsGetter
+	s.statsGetterMu.RUnlock()
+	if getter == nil {
+		return nil
+	}
+	netStats := getter.Get(uint32(ssrc))
+	if netStats == nil {
+		return nil
+	}
+
+	return &SenderNetStats{
+		PacketsSent:               netStats.OutboundRTPStreamStats.PacketsSent,
+		BytesSent:                 netStats.OutboundRTPStreamStats.BytesSent,
+		HeaderBytesSent:           netStats.OutboundRTPStreamStats.HeaderBytesSent,
+		NACKCount:                 netStats.OutboundRTPStreamStats.NACKCount,
+		PLICount:                  netStats.OutboundRTPStreamStats.PLICount,
+		PacketsReceived:           netStats.RemoteInboundRTPStreamStats.PacketsReceived,
+		PacketsLost:               netStats.RemoteInboundRTPStreamStats.PacketsLost,
+		Jitter:                    netStats.RemoteInboundRTPStreamStats.Jitter,
+		FractionLost:              netStats.RemoteInboundRTPStreamStats.FractionLost,
+		RoundTripTime:             netStats.RemoteInboundRTPStreamStats.RoundTripTime,
+		TotalRoundTripTime:        netStats.RemoteInboundRTPStreamStats.TotalRoundTripTime,
+		RoundTripTimeMeasurements: netStats.RemoteInboundRTPStreamStats.RoundTripTimeMeasurements,
+	}
+}
+
 // GetTrackStats returns the latest cumulative TrackStats for the given video
 // track. Returns nil when the track does not exist. Network fields are zero
 // until the stats interceptor has observed traffic for the track's SSRC and

--- a/sender/rtc_sender_test.go
+++ b/sender/rtc_sender_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pion/mediadevices/pkg/codec"
 	"github.com/pion/mediadevices/pkg/io/video"
 	"github.com/pion/mediadevices/pkg/prop"
+	"github.com/pion/webrtc/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -722,6 +723,85 @@ func TestRTCSender_GetTrackStats_QualityLimitation(t *testing.T) {
 			"cpu-limited seconds should accumulate on buffer eviction")
 		assert.Zero(t, got.QualityLimitationBandwidthSeconds)
 	})
+}
+
+func TestRTCSender_LookupNetStatsBySSRC_NilGetter(t *testing.T) {
+	// Before SetupPeerConnection, statsGetter is unset. The lookup must return
+	// nil cleanly rather than panic — callers (e.g. consumers polling each
+	// tick) shouldn't have to guard against pre-bind state themselves.
+	sender, err := NewRTCSender()
+	require.NoError(t, err)
+	defer func() { _ = sender.Close() }()
+
+	assert.Nil(t, sender.LookupNetStatsBySSRC(webrtc.SSRC(12345)))
+}
+
+func TestRTCSender_LookupNetStatsBySSRC_MissingSSRC(t *testing.T) {
+	// With a getter installed but returning nil for the requested SSRC (no
+	// traffic observed yet for that sender), the lookup must return nil.
+	sender, err := NewRTCSender()
+	require.NoError(t, err)
+	defer func() { _ = sender.Close() }()
+
+	sender.statsGetterMu.Lock()
+	sender.statsGetter = &mockStatsGetter{stats: nil}
+	sender.statsGetterMu.Unlock()
+
+	assert.Nil(t, sender.LookupNetStatsBySSRC(webrtc.SSRC(12345)))
+}
+
+func TestRTCSender_LookupNetStatsBySSRC_PopulatesFields(t *testing.T) {
+	// With a getter returning canned stats, every outbound and remote-inbound
+	// field flows through to the SenderNetStats result. Mirrors the
+	// equivalent TrackStats coverage so behavior between the two entry points
+	// stays in lockstep.
+	sender, err := NewRTCSender()
+	require.NoError(t, err)
+	defer func() { _ = sender.Close() }()
+
+	sender.statsGetterMu.Lock()
+	sender.statsGetter = &mockStatsGetter{
+		stats: &stats.Stats{
+			OutboundRTPStreamStats: stats.OutboundRTPStreamStats{
+				SentRTPStreamStats: stats.SentRTPStreamStats{
+					PacketsSent: 4321,
+					BytesSent:   210987,
+				},
+				HeaderBytesSent: 3500,
+				NACKCount:       7,
+				PLICount:        3,
+			},
+			RemoteInboundRTPStreamStats: stats.RemoteInboundRTPStreamStats{
+				ReceivedRTPStreamStats: stats.ReceivedRTPStreamStats{
+					PacketsReceived: 4200,
+					PacketsLost:     21,
+					Jitter:          0.125,
+				},
+				FractionLost:              0.005,
+				RoundTripTime:             20 * time.Millisecond,
+				TotalRoundTripTime:        2 * time.Second,
+				RoundTripTimeMeasurements: 50,
+			},
+		},
+	}
+	sender.statsGetterMu.Unlock()
+
+	got := sender.LookupNetStatsBySSRC(webrtc.SSRC(987654))
+	require.NotNil(t, got)
+
+	assert.Equal(t, uint64(4321), got.PacketsSent)
+	assert.Equal(t, uint64(210987), got.BytesSent)
+	assert.Equal(t, uint64(3500), got.HeaderBytesSent)
+	assert.Equal(t, uint32(7), got.NACKCount)
+	assert.Equal(t, uint32(3), got.PLICount)
+
+	assert.Equal(t, uint64(4200), got.PacketsReceived)
+	assert.Equal(t, int64(21), got.PacketsLost)
+	assert.InDelta(t, 0.125, got.Jitter, 0.0001)
+	assert.InDelta(t, 0.005, got.FractionLost, 0.0001)
+	assert.Equal(t, 20*time.Millisecond, got.RoundTripTime)
+	assert.Equal(t, 2*time.Second, got.TotalRoundTripTime)
+	assert.Equal(t, uint64(50), got.RoundTripTimeMeasurements)
 }
 
 func TestTrackStats_ZeroValueIsValid(t *testing.T) {


### PR DESCRIPTION
## Summary

`RTCSender.GetTrackStats(trackID)` walks `s.tracks`, which only holds entries created through `AddVideoTrack`. Consumers that add senders directly to the underlying `PeerConnection` (e.g. via `pc.AddTrack` for pre-encoded sample tracks published alongside bwe-test-managed video tracks) currently have no way to read their pion stats-interceptor counters — the getter is private, and pion's own `pc.GetStats()` does not emit `OutboundRTPStreamStats` in this code path.

This adds a small by-SSRC variant, `LookupNetStatsBySSRC`, returning just the network-side fields via a new `SenderNetStats` type (no pipeline/encoder counters, which don't apply to externally-added senders). RTT-bearing fields stay zero until an RTCP RR arrives for the SSRC, matching `GetTrackStats`' contract.

No behavior change for existing callers.

## Changes
- `SenderNetStats` type: per-SSRC network-side subset of `TrackStats`.
- `RTCSender.LookupNetStatsBySSRC(ssrc)`: returns nil when the stats interceptor is unbound or has no entry for the SSRC.

## Testing
- `go build ./...`, `go vet ./sender/` clean.
- New tests: nil-getter, missing-SSRC, and full field population — all pass.
- Full `sender` package test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)