### PR TITLE
sender: make capture-time RTP rewrite opt-in

### DIFF
--- a/sender/capture_timestamp.go
+++ b/sender/capture_timestamp.go
@@ -28,8 +28,24 @@ import (
 type captureTimestampInterceptor struct {
 	interceptor.NoOp
 
+	// rewrite gates the RTP-timestamp overwrite. It is DISABLED by default:
+	// replacing the packetizer's clock with an external wall clock breaks any
+	// track whose sending is gated outside the RTP stack (e.g. a simulcast-like
+	// setup where a track is allocated zero bitrate and starts sending later) —
+	// such a track begins mid-session with a base derived from wall time and the
+	// receiver never renders it. Enable with sender.CaptureTimestampRewrite()
+	// only when every track sends continuously for the session's lifetime.
+	rewrite atomic.Bool
+
 	mu    sync.Mutex
 	slots map[uint32]*atomic.Int64 // ssrc -> capture time (unix microseconds), 0 = none
+}
+
+// SetRewriteEnabled turns the RTP-timestamp overwrite on or off. Capture times
+// supplied via SetCaptureTSUs are still recorded when disabled, so callers that
+// only want capture-time telemetry are unaffected.
+func (it *captureTimestampInterceptor) SetRewriteEnabled(enabled bool) {
+	it.rewrite.Store(enabled)
 }
 
 func newCaptureTimestampInterceptor() *captureTimestampInterceptor {
@@ -102,8 +118,9 @@ func (it *captureTimestampInterceptor) BindLocalStream(
 			}
 
 			// Apply the capture-derived timestamp to every packet of the frame,
-			// keeping it constant across the frame's packets.
-			if frameValid {
+			// keeping it constant across the frame's packets. Skipped unless the
+			// rewrite was explicitly enabled — see the `rewrite` field.
+			if frameValid && it.rewrite.Load() {
 				header.Timestamp = frameRTPTS
 			}
 

--- a/sender/capture_timestamp_test.go
+++ b/sender/capture_timestamp_test.go
@@ -37,6 +37,7 @@ func bindCapture(it *captureTimestampInterceptor, sink interceptor.RTPWriter) in
 // is overwritten with captureUs*9/100 (mod 2^32), constant across a frame.
 func TestCaptureTimestampInterceptor_EncodesCaptureTime(t *testing.T) {
 	it := newCaptureTimestampInterceptor()
+	it.SetRewriteEnabled(true)
 	sink := &captureCollector{}
 	w := bindCapture(it, sink)
 
@@ -81,4 +82,43 @@ func TestCaptureTimestampInterceptor_RemoveSSRC(t *testing.T) {
 	// Removing an unknown SSRC is a no-op.
 	it.RemoveSSRC(0xDEAD)
 	assert.Len(t, it.slots, 1)
+}
+
+// TestCaptureTimestampInterceptor_DisabledByDefault asserts the rewrite is off
+// unless explicitly enabled, so a capture time supplied for telemetry does not
+// silently replace the packetizer's clock. Overwriting it breaks any track whose
+// sending is gated outside the RTP stack: such a track starts mid-session with a
+// wall-clock-derived base and receivers never render it.
+func TestCaptureTimestampInterceptor_DisabledByDefault(t *testing.T) {
+	it := newCaptureTimestampInterceptor()
+	sink := &captureCollector{}
+	w := bindCapture(it, sink)
+
+	it.SetCaptureTSUs(testCaptureSSRC, 1_751_000_000_000_000)
+	_, _ = w.Write(&rtp.Header{Timestamp: 4242}, nil, nil)
+
+	// Packetizer timestamp preserved, capture time still recorded for callers
+	// that read it for telemetry.
+	assert.Equal(t, []uint32{4242}, sink.timestamps)
+	assert.Equal(t, int64(1_751_000_000_000_000), it.slot(testCaptureSSRC).Load())
+}
+
+// TestCaptureTimestampInterceptor_RewriteToggle asserts the gate takes effect
+// per frame, so enabling and disabling at runtime is honored.
+func TestCaptureTimestampInterceptor_RewriteToggle(t *testing.T) {
+	it := newCaptureTimestampInterceptor()
+	sink := &captureCollector{}
+	w := bindCapture(it, sink)
+
+	captureUs := int64(1_751_000_000_000_000)
+	it.SetCaptureTSUs(testCaptureSSRC, captureUs)
+	want := uint32(captureUs * 9 / 100) //nolint:gosec // intentional 32-bit wrap
+
+	_, _ = w.Write(&rtp.Header{Timestamp: 100}, nil, nil)
+	it.SetRewriteEnabled(true)
+	_, _ = w.Write(&rtp.Header{Timestamp: 200}, nil, nil)
+	it.SetRewriteEnabled(false)
+	_, _ = w.Write(&rtp.Header{Timestamp: 300}, nil, nil)
+
+	assert.Equal(t, []uint32{100, want, 300}, sink.timestamps)
 }

--- a/sender/option.go
+++ b/sender/option.go
@@ -7,6 +7,7 @@
 package sender
 
 import (
+	"errors"
 	"io"
 	"time"
 
@@ -62,6 +63,31 @@ func PacketLogWriter(rtpWriter, rtcpWriter io.Writer) Option {
 func DefaultInterceptors() Option {
 	return func(sender ConfigurableWebRTCSender) error {
 		return webrtc.RegisterDefaultInterceptors(sender.GetMediaEngine(), sender.GetRegistry())
+	}
+}
+
+var errCaptureTimestampUnsupported = errors.New(
+	"CaptureTimestampRewrite requires an *RTCSender")
+
+// CaptureTimestampRewrite returns an Option that encodes each frame's capture
+// time (supplied via SetCaptureTSUs) into the outgoing RTP timestamp, so the
+// capture instant survives an SFU that strips header extensions on egress.
+//
+// Off by default, and unsafe for tracks whose sending is gated outside the RTP
+// stack: a track that is idle and then starts sending mid-session begins with a
+// timestamp base derived from wall time, and receivers do not render it. There
+// is no way to both preserve the packetizer's timeline and carry an absolute
+// capture instant in the same field, so prefer an out-of-band channel (e.g. a
+// data channel keyed by RTP timestamp) when tracks may start or stop.
+func CaptureTimestampRewrite() Option {
+	return func(sender ConfigurableWebRTCSender) error {
+		rtcSender, ok := sender.(*RTCSender)
+		if !ok {
+			return errCaptureTimestampUnsupported
+		}
+		rtcSender.captureTimestamp.SetRewriteEnabled(true)
+
+		return nil
 	}
 }
 


### PR DESCRIPTION
## Problem

`captureTimestampInterceptor` overwrites every frame's RTP timestamp with the supplied capture time (`captureUs*9/100`). That is unsafe for any track whose sending is gated outside the RTP stack: while such a track is idle it emits no packets, but the capture clock keeps advancing, so when it starts sending it enters mid-session with a base derived from wall time and receivers never render it. Tracks that send continuously from session start are unaffected, which is why this went unnoticed.

## Reproduction

14 outbound camera tracks, where only the first 5 are allocated non-zero bitrate at startup and the remaining 9 are switched on later by an operator request. Every late-started track stayed black despite being funded, encoding and sending; the 5 continuous ones were fine throughout.

Isolated by building the same consumer against a matrix of variants (one variable at a time, each run validated by logging the funding transition and the per-track encode counters):

| variant | late-started tracks render? |
| --- | --- |
| as-is | no |
| `FrameBuffer` capacity 2 instead of 1 | no |
| previous release (no rewrite) | yes |
| rewrite disabled, everything else identical | yes |
| rewrite enabled but all tracks funded from t=0 | yes |

So the rewrite is the trigger, independent of the frame-buffer change.

## Change

Gate the overwrite behind `sender.CaptureTimestampRewrite()`, **default off**. Capture times passed to `SetCaptureTSUs` are still recorded, so callers that use them only for telemetry are unaffected.

Note there is no way to both preserve the packetizer's timeline and carry an absolute capture instant in the same field. Callers whose tracks may start or stop should carry capture time out-of-band (e.g. a data channel keyed by the RTP timestamp), which also survives an SFU that strips header extensions on egress.

## Tests

- `EncodesCaptureTime` now opts in explicitly (behavior change is intentional).
- Added `DisabledByDefault` — packetizer timestamp preserved, capture time still recorded.
- Added `RewriteToggle` — the gate is honored per frame.

Full `sender` suite passes; `gofmt` and `go vet` clean.

I have not established the receiver-side reason a wall-clock-derived base is rejected for a mid-session start, so this PR gates the hazard rather than claiming to explain it.