### PR TITLE
Pass estimator options through GCC

### DIFF
--- a/sender/gcc_options_test.go
+++ b/sender/gcc_options_test.go
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//go:build !js
+
+package sender
+
+import (
+	"testing"
+
+	"github.com/pion/interceptor/pkg/gcc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Options passed to GCC must reach the estimator. Without the pass-through there
+// is no way to configure anything the two bitrate arguments do not cover.
+func TestNewGCCFactoryAppliesExtraOptions(t *testing.T) {
+	var applied bool
+	marker := func(*gcc.SendSideBWE) error {
+		applied = true
+
+		return nil
+	}
+
+	est, err := newGCCFactory(500_000, 1_500_000, marker)()
+	require.NoError(t, err)
+	require.NotNil(t, est)
+	defer func() { assert.NoError(t, est.Close()) }()
+
+	assert.True(t, applied, "an option passed to newGCCFactory must reach NewSendSideBWE")
+}
+
+// extra is appended after the bitrate options, so a caller can override them.
+func TestExtraOptionsOverrideTheBitrateArguments(t *testing.T) {
+	est, err := newGCCFactory(500_000, 1_500_000, gcc.SendSideBWEInitialBitrate(900_000))()
+	require.NoError(t, err)
+	require.NotNil(t, est)
+	defer func() { assert.NoError(t, est.Close()) }()
+
+	assert.Equal(t, 900_000, est.GetTargetBitrate(),
+		"the later option must win over the initialBitrate argument")
+}
+
+// The variadic addition must not break existing two-argument callers.
+func TestGCCRemainsCallableWithTwoArguments(t *testing.T) {
+	s, err := NewRTCSender(GCC(500_000, 1_500_000))
+	require.NoError(t, err)
+	assert.NotNil(t, s)
+}

--- a/sender/option.go
+++ b/sender/option.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pion/bwe-test/logging"
 	"github.com/pion/interceptor"
 	"github.com/pion/interceptor/pkg/cc"
+	"github.com/pion/interceptor/pkg/gcc"
 	"github.com/pion/interceptor/pkg/packetdump"
 	plogging "github.com/pion/logging"
 	"github.com/pion/transport/v4/vnet"
@@ -77,15 +78,17 @@ func CCLogWriter(w io.Writer) Option {
 // GCC returns an Option that configures Google Congestion Control with the
 // specified initial bitrate and max bitrate (in bps). A maxBitrate of 0 means
 // no cap (uses GCC default of 50 Mbps).
-func GCC(initialBitrate, maxBitrate int) Option {
+// GCC configures send-side bandwidth estimation. extra is passed through to the
+// estimator, so a caller can set options the two bitrate arguments do not cover.
+func GCC(initialBitrate, maxBitrate int, extra ...gcc.Option) Option {
 	return func(sender ConfigurableWebRTCSender) error {
 		if rtcSender, ok := sender.(*RTCSender); ok {
 			rtcSender.gccConfigured = true
 
-			return rtcSender.setupGCC(initialBitrate, maxBitrate)
+			return rtcSender.setupGCC(initialBitrate, maxBitrate, extra...)
 		}
 		// Fallback for other ConfigurableWebRTCSender types.
-		controller, err := cc.NewInterceptor(newGCCFactory(initialBitrate, maxBitrate))
+		controller, err := cc.NewInterceptor(newGCCFactory(initialBitrate, maxBitrate, extra...))
 		if err != nil {
 			return err
 		}

--- a/sender/rtc_sender.go
+++ b/sender/rtc_sender.go
@@ -284,20 +284,25 @@ func NewRTCSender(opts ...Option) (*RTCSender, error) {
 // newGCCFactory builds the send-side BWE estimator factory for the cc
 // interceptor, applying the initial bitrate and an optional max cap (0 = no
 // cap). Shared by setupGCC and the GCC option's fallback path.
-func newGCCFactory(initialBitrate, maxBitrate int) func() (cc.BandwidthEstimator, error) {
+// newGCCFactory builds estimators for each PeerConnection. extra is appended
+// after the bitrate options, so a caller can override anything they set.
+func newGCCFactory(
+	initialBitrate, maxBitrate int, extra ...gcc.Option,
+) func() (cc.BandwidthEstimator, error) {
 	return func() (cc.BandwidthEstimator, error) {
 		opts := []gcc.Option{gcc.SendSideBWEInitialBitrate(initialBitrate)}
 		if maxBitrate > 0 {
 			opts = append(opts, gcc.SendSideBWEMaxBitrate(maxBitrate))
 		}
+		opts = append(opts, extra...)
 
 		return gcc.NewSendSideBWE(opts...)
 	}
 }
 
-func (s *RTCSender) setupGCC(initialBitrate, maxBitrate int) error {
+func (s *RTCSender) setupGCC(initialBitrate, maxBitrate int, extra ...gcc.Option) error {
 	s.maxBitrate = maxBitrate
-	controller, err := cc.NewInterceptor(newGCCFactory(initialBitrate, maxBitrate))
+	controller, err := cc.NewInterceptor(newGCCFactory(initialBitrate, maxBitrate, extra...))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The `GCC` option constructs the estimator itself, so a caller can only influence it through the two bitrate arguments:

```go
opts := []gcc.Option{gcc.SendSideBWEInitialBitrate(initialBitrate)}
if maxBitrate > 0 {
    opts = append(opts, gcc.SendSideBWEMaxBitrate(maxBitrate))
}

return gcc.NewSendSideBWE(opts...)
```

Every other `gcc.Option` — the pacer, and anything added to that package later — is unreachable. Configuring the estimator at all currently means editing this package.

This accepts a variadic `...gcc.Option` on `GCC`, `setupGCC` and `newGCCFactory`, and appends it after the bitrate options:

```go
opts = append(opts, extra...)
```

Appending last is deliberate, so a caller can also override the two bitrate options rather than only add to them.

**Backward compatible.** Adding a variadic parameter does not change existing call sites, so the two-argument callers in `examples/` and the tests are untouched. `TestGCCRemainsCallableWithTwoArguments` pins that.

Three tests: that an option reaches `NewSendSideBWE`, that a later option overrides the `initialBitrate` argument, and that the two-argument form still compiles and runs. Removing the `append` fails the first two.

`gofmt`, `go vet` and `go test ./sender/` are green.
